### PR TITLE
3 core socket programming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+webserv

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@
 webserv
 
 # Editor settings
-.vscode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 *.out
 *.app
 webserv
+
+# Editor settings
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"C_Cpp.default.compilerPath": "/usr/bin/g++"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,248 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    Makefile                                           :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2023/07/28 13:03:05 by gwolf             #+#    #+#              #
+#    Updated: 2024/03/15 13:34:53 by sqiu             ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+# ******************************
+# *     Verbosity              *
+# ******************************
+
+# Set VERBOSE=1 to echo all commands
+ifeq ($(VERBOSE),1)
+	SILENT =
+else
+	SILENT = @
+endif
+
+# ******************************
+# *     Text effects           *
+# ******************************
+
+RESET := \033[0m
+BOLD := \033[1m
+BLACK := \033[30m
+GREEN := \033[32m
+YELLOW := \033[33m
+RED := \033[31m
+BLUE := \033[34m
+
+# ******************************
+# *     Directories            *
+# ******************************
+
+SRC_DIR := src
+
+# Base directory for object files
+OBJ_DIR := obj
+
+# Subdirectory for header files
+INC_DIR := inc
+
+# Subdirectories for dependency files
+DEP_DIR := $(OBJ_DIR)/dep
+
+# Subdirectory for log files
+LOG_DIR := log
+
+# ******************************
+# *     Vars for compiling     *
+# ******************************
+
+CXX := c++
+CPPFLAGS := -I $(INC_DIR)
+CXXFLAGS = -Wall -Werror -Wextra -std=c++98 -pedantic
+DEPFLAGS = -MT $@ -MMD -MP -MF $(DEP_DIR)/$*.Td
+COMPILE = $(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) -c
+POSTCOMPILE = @mv -f $(DEP_DIR)/$*.Td $(DEP_DIR)/$*.d && touch $@
+
+# ******************************
+# *     Targets                *
+# ******************************
+
+# Target
+NAME := webserv
+
+# ******************************
+# *     Source files           *
+# ******************************
+
+SRC:= 	main.cpp \
+		Server.cpp
+
+# ******************************
+# *     Object files           *
+# ******************************
+
+OBJS = 	$(addprefix $(OBJ_DIR)/, $(SRC:.cpp=.o))
+
+# ******************************
+# *     Dependency files       *
+# ******************************
+
+DEPFILES =	$(SRC:%.cpp=$(DEP_DIR)/%.d)
+
+# ******************************
+# *     Log files              *
+# ******************************
+
+LOG_FILE = $(LOG_DIR)/$(shell date "+%Y-%m-%d-%H-%M-%S")
+LOG_VALGRIND = $(LOG_FILE)_valgrind.log
+LOG_PERF = $(LOG_FILE)_perf.data
+
+# ******************************
+# *     Default target         *
+# ******************************
+
+.PHONY: all
+all: $(NAME)
+
+# ******************************
+# *     NAME linkage           *
+# ******************************
+
+# Linking the NAME target
+$(NAME): $(OBJS)
+	@printf "$(YELLOW)$(BOLD)link binary$(RESET) [$(BLUE)$@$(RESET)]\n"
+	$(SILENT)$(CXX) $(OBJS) -o $@
+	@printf "$(YELLOW)$(BOLD)compilation successful$(RESET) [$(BLUE)$@$(RESET)]\n"
+	@printf "$(BOLD)$(GREEN)$(NAME) created!$(RESET)\n"
+
+# ******************************
+# *     Special targets        *
+# ******************************
+
+# This target uses perf for profiling.
+.PHONY: profile
+profile: check_perf_installed $(NAME) | $(LOG_DIR)
+	@printf "$(YELLOW)$(BOLD)Run for profiling with perf$(RESET) [$(BLUE)$@$(RESET)]\n"
+	$(eval NEW_LOG_FILE=$(LOG_PERF))
+	$(SILENT)perf record -g -o $(NEW_LOG_FILE) ./$(NAME)
+	@printf "$(YELLOW)$(BOLD)Saved log file$(RESET) [$(BLUE)$@$(RESET)]\n"
+	@printf "$(NEW_LOG_FILE)\n"
+	@printf "$(YELLOW)$(BOLD)Run perf report$(RESET) [$(BLUE)$@$(RESET)]\n"
+	$(SILENT)perf report -g -i $(NEW_LOG_FILE)
+
+# Check if perf is installed. If not exit with error.
+.PHONY: check_perf_installed
+check_perf_installed:
+	@command -v perf >/dev/null 2>&1 || { \
+		echo >&2 "perf is not installed. Please install perf to continue."; exit 1; \
+	}
+
+# Perform memory check on NAME.
+.PHONY: valgr
+valgr: $(NAME) | $(LOG_DIR)
+	$(SILENT)valgrind	--leak-check=full\
+						--show-leak-kinds=all\
+						--track-fds=yes\
+						--log-file=$(LOG_VALGRIND)\
+						./$(NAME)
+	$(SILENT)ls -dt1 $(LOG_DIR)/* | head -n 1 | xargs less
+
+# ******************************
+# *     Object compiling and   *
+# *     dependecy creation     *
+# ******************************
+
+# File counter for status output
+TOTAL_FILES := $(words $(OBJS))
+CURRENT_FILE := 0
+
+# Create object and dependency files
+# $(DEP_DIR)/%.d =	Declare the generated dependency file as a prerequisite of the target,
+# 					so that if it’s missing the target will be rebuilt.
+# | $(DEPDIR) = 	Declare the dependency directory as an order-only prerequisite of the target,
+# 					so that it will be created when needed.
+# $(eval ...) =		Increment file counter.
+# $(eval ...) =		Increment file counter.
+# $(POSTCOMPILE) =	Move temp dependency file and touch object to ensure right timestamps.
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp message $(DEP_DIR)/%.d | $(DEP_DIR)
+	$(eval CURRENT_FILE=$(shell echo $$(($(CURRENT_FILE) + 1))))
+	@echo "($(CURRENT_FILE)/$(TOTAL_FILES)) Compiling $(BOLD)$< $(RESET)"
+	$(SILENT)$(COMPILE) $< -o $@
+	$(SILENT)$(POSTCOMPILE)
+
+# Print message only if there are objects to compile
+.INTERMEDIATE: message
+message:
+	@printf "$(YELLOW)$(BOLD)compile objects$(RESET) [$(BLUE)$@$(RESET)]\n"
+
+# Create subdirectory if it doesn't exist
+$(DEP_DIR) $(LOG_DIR):
+	@printf "$(YELLOW)$(BOLD)create subdir$(RESET) [$(BLUE)$@$(RESET)]\n"
+	@echo $@
+	$(SILENT)mkdir -p $@
+
+# Mention each dependency file as a target, so that make won’t fail if the file doesn’t exist.
+$(DEPFILES):
+
+# ******************************
+# *     Cleanup                *
+# ******************************
+
+# Remove all object files and dependency files
+.PHONY: clean
+clean:
+	@printf "$(YELLOW)$(BOLD)clean$(RESET) [$(BLUE)$@$(RESET)]\n"
+	@rm -rf $(OBJ_DIR)
+	@printf "$(RED)removed dir $(OBJ_DIR)$(RESET)\n"
+
+# Remove all object, dependency, binaries and log files
+# Remove all object, dependency, binaries and log files
+.PHONY: fclean
+fclean: clean
+	@rm -rf $(NAME)*
+	@printf "$(RED)removed binaries $(NAME)*$(RESET)\n"
+	@rm -rf $(LOG_DIR)
+	@printf "$(RED)removed subdir $(LOG_DIR)$(RESET)\n"
+	@echo
+
+# ******************************
+# *     Recompilation          *
+# ******************************
+
+.PHONY: re
+re: fclean all
+
+# ******************************
+# *     Various                *
+# ******************************
+
+# Include the dependency files that exist. Use wildcard to avoid failing on non-existent files.
+# Needs to be last target
+include $(wildcard $(DEPFILES))
+
+# ******************************
+# *     Help Target            *
+# ******************************
+
+.PHONY: help
+help:
+	@echo "$(GREEN)$(BOLD)$(NAME) Makefile Help$(RESET)"
+	@echo "This Makefile automates the compilation and cleaning processes for $(NAME)."
+	@echo "It supports various targets and can be customized with different variables."
+	@echo "Below are the available targets and variables you can use."
+	@echo ""
+	@echo "$(YELLOW)Targets:$(RESET)"
+	@echo "  all         - Compiles the default version of the miniRT program."
+	@echo "  clean       - Removes object files and dependency files."
+	@echo "  fclean      - Performs 'clean' and also removes binaries and log files."
+	@echo "  re          - Performs 'fclean' and then 'all'."
+	@echo "  valgr       - Runs the program with Valgrind to check for memory leaks."
+	@echo "  profile     - Profiles the program using 'perf'."
+	@echo ""
+	@echo "$(YELLOW)Variables:$(RESET)"
+	@echo "  VERBOSE=1   - Echoes all commands if set to 1."
+	@echo ""
+	@echo "$(YELLOW)Examples:$(RESET)"
+	@echo "  make all VERBOSE=1   - Compiles the default target with command echoing."
+	@echo ""
+	@echo "For more detailed information, read the comments within the Makefile itself."

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/28 13:03:05 by gwolf             #+#    #+#              #
-#    Updated: 2024/03/15 13:34:53 by sqiu             ###   ########.fr        #
+#    Updated: 2024/06/05 23:52:30 by sqiu             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -195,7 +195,6 @@ clean:
 	@rm -rf $(OBJ_DIR)
 	@printf "$(RED)removed dir $(OBJ_DIR)$(RESET)\n"
 
-# Remove all object, dependency, binaries and log files
 # Remove all object, dependency, binaries and log files
 .PHONY: fclean
 fclean: clean

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -1,6 +1,10 @@
 #ifndef SERVER_HPP
 # define SERVER_HPP
 
+/* ====== LIBRARIES ====== */
+
+#include <iostream>
+#include <stdexcept>
 #include <sys/epoll.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,12 +13,14 @@
 #include <netinet/in.h>
 #include <algorithm>
 #include <errno.h>
-#include <stdexcept>
-#include <iostream>
+
+/* ====== DEFINITIONS ====== */
 
 #define MAX_EVENTS 10
 #define PORT 8080
 #define BUFFER_SIZE 1024
+
+/* ====== CLASS DECLARATION ====== */
 
 class Server{
     private:

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -1,5 +1,4 @@
-#ifndef SERVER_HPP
-# define SERVER_HPP
+#pragma once
 
 /* ====== LIBRARIES ====== */
 
@@ -38,5 +37,3 @@ class Server{
                 void    acceptConnection();
                 void    handleConnections(int clientSock);
 };
-
-#endif

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -7,7 +7,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
-#include <string.h>
 #include <algorithm>
 #include <errno.h>
 #include <stdexcept>
@@ -18,9 +17,13 @@
 
 class Server{
     private:
-                int server_sock, client_sock, epfd, nfds;
-	            struct sockaddr_in client_addr;
-	            struct epoll_event ev, events[MAX_EVENTS];
+                int					_serverSock;
+				int					_clientSock;
+				int					_epfd;
+				int					_nfds;
+	            struct sockaddr_in	_clientAddr;
+	            struct epoll_event	_ev;
+				struct epoll_event	_events[MAX_EVENTS];
 
     public:
                 Server();

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -13,6 +13,7 @@
 #include <netinet/in.h>
 #include <algorithm>
 #include <errno.h>
+#include <string.h>
 
 /* ====== DEFINITIONS ====== */
 

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -26,9 +26,6 @@ class Server{
     private:
                 int					_serverSock;
 				int					_epfd;
-	            struct sockaddr_in	_clientAddr;
-	            struct epoll_event	_ev;
-				struct epoll_event	_events[MAX_EVENTS];
 
     public:
                 Server();
@@ -36,7 +33,7 @@ class Server{
 
                 void    run();
                 void    acceptConnection();
-                void    handleConnections(int index);
+                void    handleConnections(int clientSock);
 };
 
 #endif

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <errno.h>
 #include <string.h>
+#include <map>
 
 /* ====== DEFINITIONS ====== */
 
@@ -25,9 +26,9 @@
 
 class Server{
     private:
-                int				m_serverSock;
-				int				m_epfd;
-				std::string		m_requestString;
+                int							m_serverSock;
+				int							m_epfd;
+				std::map<int,std::string>	m_requestStrings;
 
     public:
                 Server();

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -1,0 +1,32 @@
+#ifndef SERVER_HPP
+# define SERVER_HPP
+
+#include <sys/epoll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <algorithm>
+#include <errno.h>
+
+#define MAX_EVENTS 10
+#define PORT 8080
+
+class Server{
+    private:
+                int server_sock, client_sock, epfd, nfds;
+	            struct sockaddr_in client_addr;
+	            struct epoll_event ev, events[MAX_EVENTS];
+
+    public:
+                Server();
+                ~Server();
+
+                void    run();
+                void    acceptConnection();
+                void    handleConnections(int index);
+};
+
+#endif

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -14,13 +14,12 @@
 
 #define MAX_EVENTS 10
 #define PORT 8080
+#define BUFFER_SIZE 1024
 
 class Server{
     private:
                 int					_serverSock;
-				int					_clientSock;
 				int					_epfd;
-				int					_nfds;
 	            struct sockaddr_in	_clientAddr;
 	            struct epoll_event	_ev;
 				struct epoll_event	_events[MAX_EVENTS];

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <algorithm>
 #include <errno.h>
+#include <stdexcept>
+#include <iostream>
 
 #define MAX_EVENTS 10
 #define PORT 8080

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -25,8 +25,9 @@
 
 class Server{
     private:
-                int					_serverSock;
-				int					_epfd;
+                int				m_serverSock;
+				int				m_epfd;
+				std::string		m_requestString;
 
     public:
                 Server();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -116,11 +116,8 @@ void    Server::run(){
 		struct epoll_event	events[MAX_EVENTS];
         // Blocking call to epoll_wait
         int	nfds = epoll_wait(_epfd, events, MAX_EVENTS, -1);
-        if (nfds < 0) {
-            close(_serverSock);
-            close(_epfd);
+        if (nfds < 0)
             throw std::runtime_error("epoll_wait");
-        }
 
         for (int n = 0; n < nfds; ++n) {
             if (events[n].data.fd == _serverSock)
@@ -154,7 +151,7 @@ void    Server::acceptConnection(){
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 break; // No more pending connections
             } else {
-                std::cerr << "error: accept\n";
+                std::cerr << "error: accept: " << strerror(errno) << "\n";
                 break;
             }
         }
@@ -167,7 +164,7 @@ void    Server::acceptConnection(){
         ev.events = EPOLLIN | EPOLLET;
         ev.data.fd = clientSock;
         if (epoll_ctl(_epfd, EPOLL_CTL_ADD, clientSock, &ev) < 0) {
-            std::cerr << "error: epoll_ctl: clientSock\n";
+            std::cerr << "error: epoll_ctl: clientSock: " << strerror(errno) << "\n";
             close(clientSock);
         }
     }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -209,9 +209,9 @@ void    Server::handleConnections(int clientSock){
 			// 	RequestParser	parseSoGood; 
 
 			// 	parseSoGood.parse();
-			// 	m_requestString.clear();
+			// 	m_requestString[clientSock].clear();
 			// } else
-			// 		m_requestString.append(buffer);
+			// 		m_requestStrings[clientSock] += buffer;
 			// 
         }
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -135,13 +135,8 @@ void    Server::handleConnections(int index){
         char	buffer[BUFFER_SIZE];
         int		bytesRead = read(clientSock, buffer, BUFFER_SIZE);
         if (bytesRead < 0) {
-			if (errno == EAGAIN || errno == EWOULDBLOCK)
-				break; 
-			else{
-				std::cerr << "error: read\n";
-				close(clientSock);
-				break;
-			}
+			// No more data to be read or error with read
+			break;
         }
         else if (bytesRead == 0) {
             // Connection closed by client

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,4 +1,4 @@
-#include "../inc/Server.hpp"
+#include "Server.hpp"
 
 /* ====== HELPER FUNCTIONS ====== */
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,5 +1,7 @@
 #include "../inc/Server.hpp"
 
+/* ====== HELPER FUNCTIONS ====== */
+
 /**
  * @brief Set the socket to nonblocking mode
  * 
@@ -18,6 +20,7 @@ static void setNonblocking(int sock)
 		throw std::runtime_error("fcntl(F_SETFL)");
 	}
 }
+/* ====== CONSTRUCTOR/DESTRUCTOR ====== */
 
 Server::Server()
 {
@@ -69,6 +72,8 @@ Server::~Server()
     close(_serverSock);
     close(_epfd);
 }
+
+/* ====== MEMBER FUNCTIONS ====== */
 
 void    Server::run(){
     while (1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
 		webserv.run();
 	}
 	catch (std::exception& e){
-		std::cerr << "error" << e.what() << std::endl;
+		std::cerr << "error: " << e.what() << std::endl;
 		return 1;
 	}
 	return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include "../inc/Server.hpp"
+#include "Server.hpp"
 
 int main(int argc, char** argv)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,8 @@
 int main(int argc, char** argv)
 {
 	if (argc != 2) {
-		std::cerr << "error: arguments invalid\n";
+		std::cerr << "error: arguments invalid\nexpected: ";
+		std::cerr << argv[0] << " <config file>\n";
 		return 1;
 	}
 	(void)argv;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <stdexcept>
 #include "Server.hpp"
 
 int main(int argc, char** argv)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include "Server.hpp"
+#include "../inc/Server.hpp"
 
 int main(int argc, char** argv)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <stdexcept>
+#include "Server.hpp"
+
+int main(int argc, char** argv)
+{
+	if (argc != 2) {
+		std::cerr << "error: arguments invalid\n";
+		return 1;
+	}
+	(void)argv;
+	try{
+		Server	webserv;
+		webserv.run();
+	}
+	catch (std::exception& e){
+		std::cerr << "error" << e.what() << std::endl;
+		return 1;
+	}
+	return 0;
+}


### PR DESCRIPTION
Revision of core server:

1. Removed attributes from Server class that were only used locally (nfds, clientSock)
2. Removed checking of errno after read as it is forbidden by subject. Comes with loss of ability to handle other read errors than EWOULDBLOCK/EAGAIN. Opinions/suggestions on this matter requested.
3. Established naming convention:
- private attributes: start with underscore, eg. _serverSock
- variables: start with lower case, any following word has first letter in upper Case
- function names: start with verb, start with lower case, any following word has first letter in upper Case, eg. acceptConnection()
4. Added Macro for BUFFER_SIZE of buffer for reading incoming data
5. Added headlines/separators to structure the hpp/cpp files. We can vote on standardising this so that all our files have the same structure. 
6. Added doxygen and inline documentation

closes #3 