### PR TITLE
12 devx setup development environment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,193 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+UseCRLF:         false
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+# Special configuration
+ColumnLimit:     120
+TabWidth:        4
+UseTab:          Always
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,65 @@
+---
+Checks: "*,
+        -abseil-*,
+        -altera-*,
+        -android-*,
+        -fuchsia-*,
+        -google-*,
+        -llvm*,
+        -zircon-*,
+        -modernize-*,
+        -concurrency-mt-unsafe
+        -cppcoreguidelines-avoid-c-arrays,
+        -cppcoreguidelines-explicit-virtual-functions,
+        -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+        -hicpp-use-nullptr,
+        -hicpp-avoid-c-arrays,
+        -hicpp-use-auto,
+        -hicpp-braces-around-statements,
+        -hicpp-special-member-functions,
+        -hicpp-use-override,
+        -hicpp-use-equals-default,
+        -hicpp-no-array-decay,
+        -misc-include-cleaner,
+        -readability-braces-around-statements,
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle:     file
+CheckOptions:
+- { key: readability-identifier-naming.ClassCase,     value: CamelCase }
+- { key: readability-identifier-naming.MemberPrefix,  value: m_ }
+- { key: readability-identifier-naming.VariableCase,  value: camelBack }
+- { key: readability-identifier-naming.FunctionCase,  value: camelBack }
+- { key: readability-identifier-naming.ParameterCase, value: camelBack }
+- { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+- { key: readability-identifier-naming.StructCase,    value: CamelCase  }
+- { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions, value: true }
+- { key: cppcoreguidelines-macro-usage.CheckCapsOnly, value: true }
+...
+
+# Inline comments don't seem to be supported well in clang-tidy-14.
+# Comments after the dots are ok
+# All checks are enabled with *, then specific checks are disabled with -
+# -abseil-* : abseil specific
+# -altera-* : altera specific
+# -android-* : android specific
+# -fuchsia-* : fuchsia specific
+# -google-* : google specific
+# -llvm* : llvm specific
+# -zircon-* : zircon specific
+# -modernize-* : in general modernize checks can not be followed, since std=C++98 does not allow it
+# -concurrency-mt-unsafe : mulithreading is not allowed
+# -cppcoreguidelines-avoid-c-arrays : std:array is a C11 feature
+# -cppcoreguidelines-explicit-virtual-functions : override is a C11 feature
+# -cppcoreguidelines-pro-bounds-array-to-pointer-decay : std::span is a C20 feature. Maybe use support class
+# -hicpp-use-nullptr : nullptr is a C11 feature
+# -hicpp-avoid-c-arrays : std:array is a C11 feature
+# -hicpp-use-auto : auto keyword as placeholder is a C11 feature
+# -hicpp-braces-around-statements : webkit style does not use braces around single line statements
+# -hicpp-special-member-functions : alias for cppcoreguidelines-special-member-functions
+# -hicpp-use-override : override is a C11 feature
+# -hicpp-use-equals-default : =default is a C11 feature
+# -hicpp-no-array-decay: alias for cppcoreguidelines-pro-bounds-array-to-pointer-decay
+# -misc-include-cleaner : seems to overly aggressive check for includes
+# -readability-braces-around-statements : webkit style does not use braces around single line statements

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
+
+# Upgrade the image
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y upgrade
+
+# Install dependencies for static analysis
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -y install --no-install-recommends \
+		clang-format \
+		clang-tidy \
+		cppcheck \
+		doxygen \
+		libgtest-dev \
+		clangd \
+		bear
+
+# Setup googletest
+RUN mkdir -p $HOME/build \
+	&& cd $HOME/build \
+	&& cmake /usr/src/googletest/googletest \
+	&& make \
+	&& cp lib/libgtest* /usr/lib/ \
+	&& cd .. \
+	&& sudo rm -rf build
+
+# Setup codechecker
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#	&& apt-get -y install --no-install-recommends \
+#		python3-dev \
+#		python3-pip \
+#		python3-venv \
+#	&& pip3 install --break-system-packages codechecker

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"llvm-vs-code-extensions.vscode-clangd",
+				"cschlosser.doxdocgen"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ webserv
 
 # Editor settings
 .vscode/
+
+# clangd
+.cache/
+compile_commands.json


### PR DESCRIPTION
Add some files for project setup

### dev container

- Adds devcontainer.json and associated Dockerfile which can be used with VS Code extension "Dev Containers".
- Container is based on the C++ development example.
- Added dependencies: 
  - clang-format: formatting 
  - clang-tidy: static analysis of code
  - cppcheck: also static analysis
  - doxygen: generate documentation out of doxygen comments
  - libgtest-dev: package of google test
  - clangd: language server as alternative to IntelliSense
  - bear: used to create compile_commands.json
- Setup google test by building library (not automatically done by package)

### clang-format

- Adds .clang-format file which standardizes formatting
- Based on WebKit style
- Special config at end of file: 
  - ColumnLimit: 120 (Standard: 0). If Limit is at 0 formatting of comments does not work properly
  - TabWidth: 4 (Standard: 8). Seems to be more familiar, 8 is too much
  - UseTab: Always (Standard: Never). Use tabs instead of spaces. We discussed it and agreed that tabs are more modern than spaces
- Can be used by executable clang-format to format single files
- VSCode can also be set up to use it > Open Settings (UI) > search for Formatting > Under C/C++ configure

### clang-tidy

- Adds clang-tidy file which enables checks used for static analysis
- Enables all checks, then disables project specific one, and some not possible ones (eg C11 features)
- Also adds little configs for readability checks. E.g member variables have to use m_
- At the end comment describing why checks are disabled (inline comments are not yet supported by our clang-tidy version)

### various

- Add .cache/ (produced by clangd) and compile_commands.json (used by clangd) to gitignore

Closes #12 