### PR TITLE
11 req parsing handle chunked encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/28 13:03:05 by gwolf             #+#    #+#              #
-#    Updated: 2024/06/18 18:46:23 by sqiu             ###   ########.fr        #
+#    Updated: 2024/06/25 18:06:22 by sqiu             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -80,8 +80,9 @@ SRC:= 	main.cpp \
 		utilities.cpp
 
 TEST_SRC:=	test.cpp \
-			testRequestLine.cpp \
+			testBody.cpp \
 			testHeader.cpp \
+			testRequestLine.cpp \
 			RequestParser.cpp \
 			Server.cpp \
 			utilities.cpp

--- a/doc/reqWithBody
+++ b/doc/reqWithBody
@@ -1,0 +1,6 @@
+POST /submit-form HTTP/1.1
+Host: www.example.com
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 27
+
+field1=value1&field2=value2

--- a/doc/reqWithChunkedBody
+++ b/doc/reqWithChunkedBody
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Content-Type: text/html
+Transfer-Encoding: chunked
+
+4\r\n
+Wiki\r\n
+5\r\n
+pedia\r\n
+E\r\n
+ in\r\n
+\r\n
+chunks.\r\n
+0\r\n
+\r\n

--- a/inc/RequestParser.hpp
+++ b/inc/RequestParser.hpp
@@ -25,6 +25,7 @@ struct HTTPRequest {
 	std::map<std::string, std::string>	headers;
 	std::string							body;
 	bool								hasBody;
+	bool								chunked;
 };
 
 /* ====== CLASS DECLARATION ====== */

--- a/inc/RequestParser.hpp
+++ b/inc/RequestParser.hpp
@@ -52,7 +52,7 @@ class RequestParser {
 				void		checkForCRLF(const std::string&);
 				bool		isValidURIChar(uint8_t c) const;
 				bool		isValidHeaderFieldNameChar(uint8_t c) const;
-				int			convertHex(const std::string& chunkSize) const;
+				size_t		convertHex(const std::string& chunkSize) const;
 
 				// Getter functions
 				int			getErrorCode() const;

--- a/inc/RequestParser.hpp
+++ b/inc/RequestParser.hpp
@@ -44,12 +44,15 @@ class RequestParser {
 				void		checkHeaderName(const std::string& headerName);
 				void		checkContentLength(const std::string& headerName, std::string& headerValue);
 				void		checkTransferEncoding();
+				void		parseChunkedBody(std::istringstream& requestStream);
+				void		parseNonChunkedBody(std::istringstream& requestStream);
 
 				// Helper functions
 				std::string	checkForSpace(const std::string&);
 				void		checkForCRLF(const std::string&);
 				bool		isValidURIChar(uint8_t c) const;
 				bool		isValidHeaderFieldNameChar(uint8_t c) const;
+				int			convertHex(const std::string& chunkSize) const;
 
 				// Getter functions
 				int			getErrorCode() const;

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -29,11 +29,13 @@ class Server{
 				int							m_epfd;
 				std::map<int,std::string>	m_requestStrings;
 
+				void    acceptConnection();
+                void    handleConnections(int clientSock);
+				bool	checkForCompleteRequest(int clientSock);
+
     public:
                 Server();
                 ~Server();
 
                 void    run();
-                void    acceptConnection();
-                void    handleConnections(int clientSock);
 };

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -21,4 +21,4 @@
 #define ERR_MULTIPLE_CONTENT_LENGTH_VALUES "Invalid HTTP request: Multiple differing content-length values"
 #define ERR_INVALID_CONTENT_LENGTH "Invalid HTTP request: Invalid content-length provided"
 #define ERR_NON_FINAL_CHUNKED_ENCODING "Invalid HTTP request: Chunked encoding not the final encoding"
-#define ERR_NON_EXISTENT_CHUNKED_ENCODING "Invalid HTTP request: Chunked encoding not detected"
+#define ERR_NON_EXISTENT_TRANSFER_ENCODING "Invalid HTTP request: Transfer encoding not detected"

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -22,3 +22,8 @@
 #define ERR_INVALID_CONTENT_LENGTH "Invalid HTTP request: Invalid content-length provided"
 #define ERR_NON_FINAL_CHUNKED_ENCODING "Invalid HTTP request: Chunked encoding not the final encoding"
 #define ERR_NON_EXISTENT_TRANSFER_ENCODING "Invalid HTTP request: Transfer encoding not detected"
+
+// HTTP REQUEST BODY ERRORS
+#define ERR_NON_EXISTENT_CHUNKSIZE "Invalid HTTP request: Chunk size not detected"
+#define ERR_INVALID_HEX_CHAR "Invalid HTTP request: Invalid hex character detected"
+#define ERR_CONVERSION_HEX "Hex conversion error"

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -27,3 +27,4 @@
 #define ERR_NON_EXISTENT_CHUNKSIZE "Invalid HTTP request: Chunk size not detected"
 #define ERR_INVALID_HEX_CHAR "Invalid HTTP request: Invalid hex character detected"
 #define ERR_CONVERSION_HEX "Hex conversion error"
+#define ERR_CHUNK_SIZE "Invalid HTTP request: Indicated chunk size different than actual chunk size"

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -26,5 +26,7 @@
 // HTTP REQUEST BODY ERRORS
 #define ERR_NON_EXISTENT_CHUNKSIZE "Invalid HTTP request: Chunk size not detected"
 #define ERR_INVALID_HEX_CHAR "Invalid HTTP request: Invalid hex character detected"
-#define ERR_CONVERSION_HEX "Hex conversion error"
+#define ERR_CONVERSION_STRING_TO_HEX "String to hex conversion error"
 #define ERR_CHUNK_SIZE "Invalid HTTP request: Indicated chunk size different than actual chunk size"
+#define ERR_CONVERSION_STRING_TO_SIZE_T "String to size_t conversion error"
+#define ERR_CONTENT_LENGTH "Invalid HTTP request: Indicated content length different than actual body size"

--- a/inc/test.hpp
+++ b/inc/test.hpp
@@ -21,3 +21,9 @@ void	runHeaderTests(const std::string& name
 void	testValidHeader();
 void	testInvalidHeader();
 
+// Body Tests
+void	runBodyTests(const std::string& name
+		, size_t total
+		, const std::pair<std::string, std::string> tests[]);
+void	testValidBody();
+void	testInvalidBody();

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -165,7 +165,13 @@ bool	RequestParser::isValidHeaderFieldNameChar(uint8_t c) const
 
 /* ====== CONSTRUCTOR/DESTRUCTOR ====== */
 
-RequestParser::RequestParser() {}
+RequestParser::RequestParser()
+	: m_errorCode(0)
+	, m_requestMethod(0)
+{
+	m_request.hasBody = false;
+	m_request.chunked = false;
+}
 
 RequestParser::~RequestParser() {}
 

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -611,7 +611,8 @@ void	RequestParser::checkTransferEncoding()
 				throw std::runtime_error(ERR_NON_FINAL_CHUNKED_ENCODING);
 			}
 			m_request.chunked = true;
+			m_request.hasBody = true;
 		}
-		m_request.hasBody = true;
+		
 	}
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -543,13 +543,16 @@ void	RequestParser::checkTransferEncoding()
 	if (m_request.headers.find("Transfer-Encoding") != m_request.headers.end()) {
 		if (m_request.headers["Transfer-Encoding"].empty()) {
 			m_errorCode = 400;
-			throw std::runtime_error(ERR_NON_EXISTENT_CHUNKED_ENCODING);
+			throw std::runtime_error(ERR_NON_EXISTENT_TRANSFER_ENCODING);
 		}
 
-		std::vector<std::string>	encodings = split(m_request.headers["Transfer-Encoding"], ',');
-		if (encodings[encodings.size() - 1] != "chunked") {
-			m_errorCode = 400;
-			throw std::runtime_error(ERR_NON_FINAL_CHUNKED_ENCODING);
+		if (m_request.headers["Transfer-Encoding"].find("chunked") != std::string::npos) {
+			std::vector<std::string>	encodings = split(m_request.headers["Transfer-Encoding"], ',');
+			if (encodings[encodings.size() - 1] != "chunked") {
+				m_errorCode = 400;
+				throw std::runtime_error(ERR_NON_FINAL_CHUNKED_ENCODING);
+			}
+			m_request.chunked = true;
 		}
 		m_request.hasBody = true;
 	}

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -469,7 +469,28 @@ std::string	RequestParser::parseVersion(const std::string& requestLine)
 	return (requestLine.substr(++i));
 }
 
-
+/**
+ * @brief Parses a chunked body from the provided input stream.
+ *
+ * This function reads and processes the chunked transfer encoding format from the input stream.
+ * It reads chunks of data prefixed by their size in hexadecimal format, appends the data to the
+ * request body, and handles any formatting errors.
+ *
+ * @param requestStream The input stream containing the chunked body.
+ *
+ * @throws std::runtime_error If the chunked body format is invalid (missing CRLF or incorrect chunk size).
+ *
+ * Error codes:
+ * - ERR_MISS_CRLF: Thrown when a line does not end with a CRLF.
+ * - ERR_CHUNK_SIZE: Thrown when the chunk size does not match the specified size.
+ *
+ * Example usage:
+ * @code
+ * std::istringstream requestStream("4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n");
+ * RequestParser parser;
+ * parser.parseChunkedBody(requestStream);
+ * @endcode
+ */
 void	RequestParser::parseChunkedBody(std::istringstream& requestStream)
 {
 	int			length = 0;
@@ -508,6 +529,30 @@ void	RequestParser::parseChunkedBody(std::istringstream& requestStream)
 	}
 }
 
+/**
+ * @brief Parses a non-chunked body from the provided input stream.
+ *
+ * This function reads the entire body from the input stream, ensuring that the
+ * total length of the body matches the "Content-Length" header specified in the request.
+ * It processes each line, removing trailing carriage returns and concatenates
+ * the lines to form the complete body.
+ *
+ * @param requestStream The input stream containing the non-chunked body.
+ *
+ * @throws std::runtime_error If there is an error converting the "Content-Length" header
+ *                            to a size_t or if the body length does not match the "Content-Length" value.
+ *
+ * Error codes:
+ * - ERR_CONVERSION_STRING_TO_SIZE_T: Thrown when the conversion of "Content-Length" header to size_t fails.
+ * - ERR_CONTENT_LENGTH: Thrown when the length of the parsed body does not match the "Content-Length" value.
+ *
+ * Example usage:
+ * @code
+ * std::istringstream requestStream("This is the body of the request.\r\n");
+ * RequestParser parser;
+ * parser.parseNonChunkedBody(requestStream);
+ * @endcode
+ */
 void	RequestParser::parseNonChunkedBody(std::istringstream& requestStream)
 {
 	std::string body;

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -477,12 +477,20 @@ void	RequestParser::parseChunkedBody(std::istringstream& requestStream)
 	std::getline(requestStream, strChunkSize);
 	if (strChunkSize[strChunkSize.size() - 1] == '\r')
 		strChunkSize.erase(strChunkSize.size() - 1);
+	else {
+		m_errorCode = 400;
+		throw std::runtime_error(ERR_MISS_CRLF);
+	}
 	size_t numChunkSize = convertHex(strChunkSize);
 	while (numChunkSize > 0) {
 		std::string	chunkData;
 		std::getline(requestStream, chunkData);
 		if (chunkData[chunkData.size() - 1] == '\r')
 			chunkData.erase(chunkData.size() - 1);
+		else {
+			m_errorCode = 400;
+			throw std::runtime_error(ERR_MISS_CRLF);
+		}
 		if (chunkData.size() != numChunkSize) {
 			m_errorCode = 400;
 			throw std::runtime_error(ERR_CHUNK_SIZE);
@@ -492,6 +500,10 @@ void	RequestParser::parseChunkedBody(std::istringstream& requestStream)
 		std::getline(requestStream, strChunkSize);
 		if (strChunkSize[strChunkSize.size() - 1] == '\r')
 			strChunkSize.erase(strChunkSize.size() - 1);
+		else {
+			m_errorCode = 400;
+			throw std::runtime_error(ERR_MISS_CRLF);
+		}
 		numChunkSize = convertHex(strChunkSize);
 	}
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -679,7 +679,7 @@ void	RequestParser::checkTransferEncoding()
 		}
 
 		if (m_request.headers.at("Transfer-Encoding").find("chunked") != std::string::npos) {
-			std::vector<std::string>	encodings = split(m_request.headers["Transfer-Encoding"], ',');
+			std::vector<std::string>	encodings = split(m_request.headers.at("Transfer-Encoding"), ',');
 			if (encodings[encodings.size() - 1] != "chunked") {
 				m_errorCode = 400;
 				throw std::runtime_error(ERR_NON_FINAL_CHUNKED_ENCODING);

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -673,12 +673,12 @@ void	RequestParser::checkContentLength(const std::string& headerName, std::strin
 void	RequestParser::checkTransferEncoding()
 {
 	if (m_request.headers.find("Transfer-Encoding") != m_request.headers.end()) {
-		if (m_request.headers["Transfer-Encoding"].empty()) {
+		if (m_request.headers.at("Transfer-Encoding").empty()) {
 			m_errorCode = 400;
 			throw std::runtime_error(ERR_NON_EXISTENT_TRANSFER_ENCODING);
 		}
 
-		if (m_request.headers["Transfer-Encoding"].find("chunked") != std::string::npos) {
+		if (m_request.headers.at("Transfer-Encoding").find("chunked") != std::string::npos) {
 			std::vector<std::string>	encodings = split(m_request.headers["Transfer-Encoding"], ',');
 			if (encodings[encodings.size() - 1] != "chunked") {
 				m_errorCode = 400;

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -481,9 +481,13 @@ void	RequestParser::parseChunkedBody(std::istringstream& requestStream)
 	while (numChunkSize > 0) {
 		std::string	chunkData;
 		std::getline(requestStream, chunkData);
+		if (chunkData[chunkData.size() - 1] == '\r')
+			chunkData.erase(chunkData.size() - 1);
 		m_request.body += chunkData;
 		length += numChunkSize;
 		std::getline(requestStream, strChunkSize);
+		if (strChunkSize[strChunkSize.size() - 1] == '\r')
+			strChunkSize.erase(strChunkSize.size() - 1);
 		numChunkSize = convertHex(strChunkSize);
 	}
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -500,8 +500,10 @@ void	RequestParser::parseNonChunkedBody(std::istringstream& requestStream)
 {
 	std::string body;
 	while (std::getline(requestStream, body)) {
+		if (body[body.size() - 1] == '\r')
+			body.erase(body.size() - 1);
 		if (!m_request.body.empty())
-			body += "\n";
+			m_request.body += '\n';
 		m_request.body += body;
 	}
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -245,8 +245,7 @@ HTTPRequest	RequestParser::parseHttpRequest(const std::string& request)
         std::string headerValue;
         if (std::getline(headerStream, headerName, ':')) {
 			checkHeaderName(headerName);
-			// getline() removes trailing \r\n
-            std::getline(headerStream >> std::ws, headerValue);
+            std::getline(headerStream >> std::ws, headerValue, '\r');
 			headerValue = trimTrailingWhiteSpaces(headerValue);
 			checkContentLength(headerName, headerValue);
             m_request.headers[headerName] = headerValue;

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -559,11 +559,13 @@ void	RequestParser::parseNonChunkedBody(std::istringstream& requestStream)
 	size_t		length = 0;
 
 	while (std::getline(requestStream, body)) {
-		length += body.size() + 1;
-		if (body[body.size() - 1] == '\r')
+		if (body[body.size() - 1] == '\r') {
 			body.erase(body.size() - 1);
-		if (!m_request.body.empty())
-			m_request.body += '\n';
+			length += 1;
+		}
+		if (!requestStream.eof())
+			body += '\n';
+		length += body.size();
 		m_request.body += body;
 	}
 	size_t	contentLength = 0;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,4 +1,5 @@
 #include "Server.hpp"
+#include "RequestParser.hpp"
 
 /* ====== HELPER FUNCTIONS ====== */
 
@@ -200,18 +201,43 @@ void    Server::handleConnections(int clientSock){
             // Connection closed by client
             close(clientSock);
         } else {
-            // Echo data back to client
-            write(clientSock, buffer, bytesRead);
-			// FIXME: check requestString for complete HTTP request.
-			// If yes, hand over to request parser and then clear the requestString.
-			// If no, concatenate to requestString and exit, only to come back for remainder. 
-			// if (checkRequestString()) {
-			// 	RequestParser	parseSoGood; 
+			m_requestStrings[clientSock] += buffer;
+			size_t	headerEndPos = m_requestStrings[clientSock].find("\r\n\r\n");
+            if (headerEndPos != std::string::npos) {
+				headerEndPos += 4;
+				size_t	bodySize = m_requestStrings[clientSock].size() - headerEndPos;
+				size_t	contentLengthPos = m_requestStrings[clientSock].find("Content-Length");
+				size_t	transferEncodingPos = m_requestStrings[clientSock].find("Transfer-Encoding");
 
-			// 	parseSoGood.parse();
-			// 	m_requestString[clientSock].clear();
-			// } else
-			// 		m_requestStrings[clientSock] += buffer;
-			// 
+				if (contentLengthPos != std::string::npos && transferEncodingPos == std::string::npos){
+					unsigned long contentLength = std::strtoul(m_requestStrings[clientSock].c_str() + contentLengthPos + 15, NULL, 10);
+
+					if (bodySize >= contentLength) {
+						try{
+							RequestParser	parser;
+							parser.parseHttpRequest(m_requestStrings[clientSock]);
+						}
+						catch (std::exception& e){
+							std::cerr << "Error: " << e.what() << std::endl;
+						}
+						// response builder retrieves request and does his stuff
+					}
+				}
+				else if (transferEncodingPos != std::string::npos) {
+					std::string	tmp = m_requestStrings[clientSock].substr(transferEncodingPos);
+
+					if (tmp.find("chunked") != std::string::npos
+						&& tmp.find("0\r\n\r\n") != std::string::npos) {
+							try{
+								RequestParser	parser;
+								parser.parseHttpRequest(m_requestStrings[clientSock]);
+							}
+							catch (std::exception& e){
+								std::cerr << "Error: " << e.what() << std::endl;
+							}
+							// response builder retrieves request and does his stuff
+					} 
+				}
+			}
         }
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -2,9 +2,10 @@
 
 int	main()
 {
-	testValidRequestLine();
-	testInvalidRequestLine();
-	testValidHeader();
-	testInvalidHeader();
+	// testValidRequestLine();
+	// testInvalidRequestLine();
+	// testValidHeader();
+	// testInvalidHeader();
+	testValidBody();
 	return 0;
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -7,5 +7,6 @@ int	main()
 	// testValidHeader();
 	// testInvalidHeader();
 	testValidBody();
+	testInvalidBody();
 	return 0;
 }

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -35,8 +35,10 @@ void	testValidBody()
 			, "hello world!"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip\r\n\r\nhello \r\nworld!\r\n"
 			, ""),
-		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 16\r\n\r\nhello \r\nworld!\r\n"
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 14\r\n\r\nhello \r\nworld!"
 			, "hello \nworld!"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 16\r\n\r\nhello \r\nworld!\r\n"
+			, "hello \nworld!\n"),
 
 	};
 	runBodyTests("VALID BODY", sizeof(tests) / sizeof(tests[0]), tests);

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -34,6 +34,8 @@ void	testValidBody()
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n6\r\nhello \r\n6\r\nworld!\r\n0\r\n\r\n"
 			, "hello world!"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip\r\n\r\nhello \r\nworld!\r\n"
+			, ""),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 16\r\n\r\nhello \r\nworld!\r\n"
 			, "hello \nworld!"),
 
 	};
@@ -45,6 +47,8 @@ void	testInvalidBody()
 	std::pair<std::string, std::string>	tests[] = {
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n1\r\nhello \r\n6\r\nworld!\r\n0\r\n\r\n"
 			, "hello world!"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 3\r\n\r\nhello \r\nworld!\r\n"
+			, "hello \nworld!"),
 	};
 	runBodyTests("INVALID BODY", sizeof(tests) / sizeof(tests[0]), tests);
 }

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -41,8 +41,8 @@ void	testValidBody()
 void	testInvalidBody()
 {
 	std::pair<std::string, std::string>	tests[] = {
-		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost :       www.example.com       \r\n\r\n"
-			, "Host\nwww.example.com"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n1\r\nhello \r\n6\r\nworld!\r\n0\r\n\r\n"
+			, "hello world!"),
 	};
 	runBodyTests("INVALID BODY", sizeof(tests) / sizeof(tests[0]), tests);
 }

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -33,6 +33,8 @@ void	testValidBody()
 	std::pair<std::string, std::string>	tests[] = {
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n6\r\nhello \r\n6\r\nworld!\r\n0\r\n\r\n"
 			, "hello world!"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip\r\n\r\nhello \r\nworld!\r\n"
+			, "hello \nworld!"),
 
 	};
 	runBodyTests("VALID BODY", sizeof(tests) / sizeof(tests[0]), tests);

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -1,0 +1,48 @@
+#include "test.hpp"
+
+void	runBodyTests(const std::string& name
+		, size_t total
+		, const std::pair<std::string, std::string> tests[])
+{
+	std::cout << "\n* " << name << " *\n";
+	for (size_t i = 0; i < total; i++) {
+		std::cout << "\nTest [" << i << "]:\n" << tests[i].first << std::endl;
+		try {
+			RequestParser	p;
+			HTTPRequest		request;
+			std::string		body;
+
+			request = p.parseHttpRequest(tests[i].first);
+			
+			// Check body string
+			if (request.body == tests[i].second)
+				std::cout << "SUCCESS - Body: " << request.body << "\n";
+			else {
+				std::cerr << "FAILURE - expected: " << tests[i].second << "\n";
+				std::cerr << "received: " << request.body << "\n";
+		}
+		}
+		catch (std::exception& e) {
+			std::cerr << "Error: " << e.what() << std::endl;
+		}
+	} 
+}
+
+void	testValidBody()
+{
+	std::pair<std::string, std::string>	tests[] = {
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n6\r\nhello \r\n6\r\nworld!\r\n0\r\n\r\n"
+			, "hello world!"),
+
+	};
+	runBodyTests("VALID BODY", sizeof(tests) / sizeof(tests[0]), tests);
+}
+
+void	testInvalidBody()
+{
+	std::pair<std::string, std::string>	tests[] = {
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost :       www.example.com       \r\n\r\n"
+			, "Host\nwww.example.com"),
+	};
+	runBodyTests("INVALID BODY", sizeof(tests) / sizeof(tests[0]), tests);
+}

--- a/src/testBody.cpp
+++ b/src/testBody.cpp
@@ -49,6 +49,10 @@ void	testInvalidBody()
 			, "hello world!"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 3\r\n\r\nhello \r\nworld!\r\n"
 			, "hello \nworld!"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n6\r\nhello 6\r\nworld!\r\n0\r\n\r\n"
+			, "hello world!"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n6\r\nhello \n6\r\nworld!\r\n0\r\n\r\n"
+			, "hello world!"),
 	};
 	runBodyTests("INVALID BODY", sizeof(tests) / sizeof(tests[0]), tests);
 }

--- a/src/testHeader.cpp
+++ b/src/testHeader.cpp
@@ -44,7 +44,7 @@ void	testValidHeader()
 			, "Host\nwww.example.com\nContent-Length\n23"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 23, 23\r\n\r\n"
 			, "Host\nwww.example.com\nContent-Length\n23"),
-		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n"
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n"
 			, "Host\nwww.example.com\nTransfer-Encoding\ngzip, chunked"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip\r\n\r\n"
 			, "Host\nwww.example.com\nTransfer-Encoding\ngzip"),

--- a/src/testHeader.cpp
+++ b/src/testHeader.cpp
@@ -46,6 +46,8 @@ void	testValidHeader()
 			, "Host\nwww.example.com\nContent-Length\n23"),
 		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n"
 			, "Host\nwww.example.com\nTransfer-Encoding\ngzip, chunked"),
+		std::make_pair("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: www.example.com\r\nTransfer-Encoding: gzip\r\n\r\n"
+			, "Host\nwww.example.com\nTransfer-Encoding\ngzip"),
 	};
 	runHeaderTests("VALID HEADER", sizeof(tests) / sizeof(tests[0]), tests);
 }


### PR DESCRIPTION
Introduces ability to parse chunked bodies:

Chunked body:
- indicated by "Transfer-Encoding: chunked"
- format:
- chunk size in hex representation and CRLF
- chunk data and CRLF
- read and convert chunk size
- read chunk data and check if chunk size corresponds to actual chunk size
- end of chunked body indicated by zero-size chunk = break condition of loop

Non-chunked body:
- indicated by "Content-Length" (can be overwritten by Transfer-Encoding, then revert to chunked body)
- fix parsing to insert newlines at correct positions while reading the body line by line

Generally fix interpretation of header fields "Transfer-Encoding" and "Content-Length" according to RFC 7230 and RFC 9112.

Add tests for body parsing.

TLDR: Enhance HTTP request parser with ability to read chunked and non-chunked bodies.

close #11 