### PR TITLE
14 core call epoll with timeout value

### DIFF
--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -23,7 +23,6 @@
 
 /* ====== DEFINITIONS ====== */
 
-#define MAX_EVENTS 10
 #define PORT 8080
 #define BUFFER_SIZE 1024
 #define CONNECTION_QUEUE 10
@@ -35,6 +34,7 @@ private:
 	int m_serverSock;
 	int m_epfd;
 	std::map<int, std::string> m_requestStrings;
+    std::map<int, time_t> m_connectionLastActive;
 
 	void acceptConnection() const;
 	void handleConnections(int clientSock, RequestParser& parser);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -34,7 +34,7 @@ private:
 	int m_serverSock;
 	int m_epfd;
 	std::map<int, std::string> m_requestStrings;
-    std::map<int, time_t> m_connectionLastActive;
+	std::map<int, time_t> m_connectionLastActive;
 
 	void acceptConnection() const;
 	void handleConnections(int clientSock, RequestParser& parser);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -125,7 +125,7 @@ void Server::run()
 	RequestParser parser;
 	const int maxEvents = 10;
 	const int timeout = 5000; // epoll timeout in milliseconds
-	const int acceptedIdleTime = 10; // time until an idle connection is closed
+	const int acceptedIdleTime = 10; // time in seconds until an idle connection is closed
 
 	while (true) {
 		struct epoll_event events[maxEvents];


### PR DESCRIPTION
Add timeout value to epoll_wait to activate epoll when there have been no events for said time span.
Add tracking of last_active point in time for each connection. Epoll checks for each connection whether a predetermined idle time threshold has been breached. In case yes, the connection is closed.

This prevents idle connections to stay open endlessly.

Closes #14 