### PR TITLE
64 responsestream of responsebuilder not cleared of previous response

### DIFF
--- a/inc/Connection.hpp
+++ b/inc/Connection.hpp
@@ -32,7 +32,6 @@ public:
 	time_t m_timeSinceLastEvent; /**< Time elapsed since last action on this connection */
 	ConnectionStatus m_status; /**< Current status of the connection */
 	std::string m_buffer; /**< Bytes received from client */
-	ssize_t m_bytesReceived; /**< Number of bytes received from client */
 	HTTPRequest m_request; /**< Request of the client */
 	std::vector<ConfigServer>::const_iterator serverConfig; /**< Server configuration associated with connection */
 	std::vector<Location>::const_iterator location; /**< Location configuration associated with connection */

--- a/inc/ResponseBuilder.hpp
+++ b/inc/ResponseBuilder.hpp
@@ -11,9 +11,9 @@
  * @brief Class to build a HTTP response.
  *
  * This class is responsible to build a HTTP response based on the request received.
- * The ConfigFile is used to get the configuration of the server.
- * It uses the classes TargetResourceHandler to handle the target resource and
- * ResponseBodyHandler for the body of the response.
+ * It uses a stringstream m_responseHeader to convert variables to string. The stringstream is reused.
+ * It uses the class ResponseBodyHandler to construct the body of the response.
+ * Each time a new response is built the old one is overwritten.
  * The FileSystemPolicy passed in the constructor needs to outlive this class. It is passed to subclasses.
  * A mock of FileSystemPolicy can be used for testing.
  */
@@ -29,11 +29,10 @@ private:
 	void appendHeaders(const HTTPRequest& request);
 	std::string getMIMEType(const std::string& extension);
 	void initMIMETypes();
-	void resetStream();
+	void resetBuilder();
 
 	std::map<std::string, std::string> m_mimeTypes;
 	const FileSystemPolicy& m_fileSystemPolicy;
-	std::stringstream m_responseStream;
+	std::stringstream m_responseHeader;
 	std::string m_responseBody;
-	bool m_isFirstTime;
 };

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -63,6 +63,8 @@ public:
 	const std::map<int, Connection>& getConnections() const;
 	const std::vector<ConfigServer>& getServerConfigs() const;
 	time_t getClientTimeout() const;
+	std::vector<char>& getClientHeaderBuffer();
+	std::vector<char>& getClientBodyBuffer();
 
 	// Setters
 	bool registerVirtualServer(int serverFd, const Socket& serverSock);
@@ -105,6 +107,8 @@ private:
 	time_t m_clientTimeout; /**< Timeout for a Connection in seconds */
 	std::map<int, Socket> m_virtualServers; /**< Listening sockets of virtual servers */
 	std::map<int, Connection> m_connections; /**< Current active Connections */
+	std::vector<char> m_clientHeaderBuffer; /**< Buffer for reading request header */
+	std::vector<char> m_clientBodyBuffer; /**< Buffer for reading request body */
 	RequestParser m_requestParser; /**< Handles parsing of request */
 	FileSystemPolicy m_fileSystemPolicy; /**< Handles functions for file system manipulation */
 	ResponseBuilder m_responseBuilder; /**< Handles building of response */

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -16,7 +16,6 @@ Connection::Connection(const Socket& server, const Socket& client, const std::ve
 	, m_clientSocket(client)
 	, m_timeSinceLastEvent(std::time(0))
 	, m_status(Idle)
-	, m_bytesReceived(0)
 {
 	if (!hasValidServerConfig(*this, serverConfigs)) {
 		m_status = Closed;
@@ -28,7 +27,6 @@ bool clearConnection(Connection& connection, const std::vector<ConfigServer>& se
 	connection.m_status = Connection::Idle;
 	connection.m_request = HTTPRequest();
 	connection.m_buffer.clear();
-	connection.m_bytesReceived = 0;
 	connection.m_timeSinceLastEvent = std::time(0);
 	return (hasValidServerConfig(connection, serverConfigs));
 }

--- a/src/LogOstreamInserters.cpp
+++ b/src/LogOstreamInserters.cpp
@@ -264,7 +264,6 @@ std::ostream& operator<<(std::ostream& ostream, const Connection& connection)
 	ostream << "Client: " << connection.m_clientSocket << '\n';
 	ostream << "Time since last event: " << connection.m_timeSinceLastEvent << '\n';
 	ostream << "Status: " << connection.m_status << '\n';
-	ostream << "Bytes received: " << connection.m_bytesReceived << '\n';
 	ostream << "Request:\n" << connection.m_request;
 	ostream << "Buffer:\n" << connection.m_buffer << '\n';
 	return ostream;

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -16,7 +16,7 @@ ResponseBuilder::ResponseBuilder(const FileSystemPolicy& fileSystemPolicy)
  *
  * If the response body is empty, only the response header is returned.
  * Otherwise, the response header and body are returned.
- * The response doesn't chnage until the next buildResponse() call.
+ * The response doesn't change until the next buildResponse() call.
  * @return std::string Response.
  */
 std::string ResponseBuilder::getResponse() const

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -7,7 +7,6 @@
  */
 ResponseBuilder::ResponseBuilder(const FileSystemPolicy& fileSystemPolicy)
 	: m_fileSystemPolicy(fileSystemPolicy)
-	, m_isFirstTime(true)
 {
 	initMIMETypes();
 }
@@ -15,63 +14,69 @@ ResponseBuilder::ResponseBuilder(const FileSystemPolicy& fileSystemPolicy)
 /**
  * @brief Get the built response.
  *
- * The stream is returned as c_str() since it is reused.
- * The buffer is never cleared all the way, only reset to the beginning.
- * If str() would be returned, old parts of the stream would be included.
- * This works since every thing inserted into the string sets a new zero terminator.
+ * If the response body is empty, only the response header is returned.
+ * Otherwise, the response header and body are returned.
+ * The response doesn't chnage until the next buildResponse() call.
  * @return std::string Response.
  */
-std::string ResponseBuilder::getResponse() const { return m_responseStream.str().c_str(); } // NOLINT
+std::string ResponseBuilder::getResponse() const
+{
+	if (m_responseBody.empty())
+		return m_responseHeader.str();
+
+	return m_responseHeader.str() + m_responseBody;
+}
 
 /**
  * @brief Build the response for a given request.
  *
- * Reset the stream, to clear possible beforehand built response.
- * Execute response body handler to get the response body.
- * Build the response by appending the status line, headers and body.
+ * Reset the builder with resetBuilder(), to clear possible beforehand built response.
+ * Construct and execute a ResponseBodyHandler to construct the response body.
+ * Build the response header with appendStatusLine() and appendHeaders().
+ * The response is stored in m_responseHeader and m_responseBody. The response can be retrieved with getResponse().
  * @param request HTTP request.
  */
 void ResponseBuilder::buildResponse(HTTPRequest& request)
 {
-	resetStream();
+	resetBuilder();
 
 	LOG_DEBUG << "Building response for request: " << request.method << " " << request.uri.path;
 
 	ResponseBodyHandler responseBodyHandler(request, m_responseBody, m_fileSystemPolicy);
 	responseBodyHandler.execute();
 
-	LOG_DEBUG << "Response body: \n" << m_responseBody;
-
 	appendStatusLine(request);
 	appendHeaders(request);
-	m_responseStream << m_responseBody << "\r\n";
-	m_responseBody.clear();
+
+	LOG_DEBUG << "Response header: \n" << m_responseHeader.str();
+
+	// Response Body often contains binary data, so it is not logged.
+	// LOG_DEBUG << "Response body: \n" << m_responseBody;
 }
 
 /**
- * @brief Reset the stream to the beginning.
+ * @brief Reset the builder.
  *
- * If it is not the first time, the stream is reset to the beginning.
- * This is done to clear the stream from the previous response.
+ * The stringstream m_responseHeader is reset to an empty string and cleared to removed any potential error flags.
+ * The string m_responseBody is cleared.
  */
-void ResponseBuilder::resetStream()
+void ResponseBuilder::resetBuilder()
 {
-	if (!m_isFirstTime)
-		m_responseStream.seekp(std::ios::beg);
-
-	m_isFirstTime = false;
+	m_responseHeader.str(std::string());
+	m_responseHeader.clear();
+	m_responseBody.clear();
 }
 
 /**
  * @brief Append status line to the response.
  *
  * The status line is appended in the following format:
- * HTTP/1.1 <status code> <reason phrase>
+ * HTTP/1.1 <status code> <reason phrase> CRLF
  * @param request HTTP request.
  */
 void ResponseBuilder::appendStatusLine(const HTTPRequest& request)
 {
-	m_responseStream << "HTTP/1.1 " << request.httpStatus << ' '
+	m_responseHeader << "HTTP/1.1 " << request.httpStatus << ' '
 					 << webutils::statusCodeToReasonPhrase(request.httpStatus) << "\r\n";
 }
 
@@ -79,30 +84,30 @@ void ResponseBuilder::appendStatusLine(const HTTPRequest& request)
  * @brief Append headers to the response.
  *
  * The following headers are appended:
- * Content-Type: MIME type of the target resource.
- * Content-Length: Length of the response body.
- * Server: TriHard.
- * Date: Current date in GMT.
- * Location: Target resource if status is StatusMovedPermanently.
+ * - Content-Type: MIME type of the target resource.
+ * - Content-Length: Length of the response body.
+ * - Server: TriHard.
+ * - Date: Current date in GMT.
+ * - Location: Target resource if status is StatusMovedPermanently.
  * Delimiter.
  * @param request HTTP request.
  */
 void ResponseBuilder::appendHeaders(const HTTPRequest& request)
 {
 	// Content-Type
-	m_responseStream << "Content-Type: " << getMIMEType(webutils::getFileExtension(request.targetResource)) << "\r\n";
+	m_responseHeader << "Content-Type: " << getMIMEType(webutils::getFileExtension(request.targetResource)) << "\r\n";
 	// Content-Length
-	m_responseStream << "Content-Length: " << m_responseBody.length() << "\r\n";
+	m_responseHeader << "Content-Length: " << m_responseBody.length() << "\r\n";
 	// Server
-	m_responseStream << "Server: TriHard\r\n";
+	m_responseHeader << "Server: TriHard\r\n";
 	// Date
-	m_responseStream << "Date: " << webutils::getGMTString(time(0), "%a, %d %b %Y %H:%M:%S GMT") << "\r\n";
+	m_responseHeader << "Date: " << webutils::getGMTString(time(0), "%a, %d %b %Y %H:%M:%S GMT") << "\r\n";
 	// Location
 	if (request.httpStatus == StatusMovedPermanently) {
-		m_responseStream << "Location: " << request.targetResource << "\r\n";
+		m_responseHeader << "Location: " << request.targetResource << "\r\n";
 	}
 	// Delimiter
-	m_responseStream << "\r\n";
+	m_responseHeader << "\r\n";
 }
 
 /**

--- a/test/test_OstreamInserters.cpp
+++ b/test/test_OstreamInserters.cpp
@@ -128,7 +128,6 @@ protected:
 
 		m_connection.m_timeSinceLastEvent = 1234;
 		m_connection.m_buffer = "GET / HTTP/1.1";
-		m_connection.m_bytesReceived = 1024;
 		m_connection.m_request = m_httpRequest;
 	}
 };
@@ -233,7 +232,6 @@ TEST_F(OstreamInsertersTest, Connection)
 				"Status: "
 			 << m_connection.m_status
 			 << "\n"
-				"Bytes received: 1024\n"
 				"Request:\n"
 			 << m_httpRequest << "Buffer:\nGET / HTTP/1.1\n";
 	EXPECT_EQ(ostream.str(), expected.str());

--- a/test/test_connectionReceiveHeader.cpp
+++ b/test/test_connectionReceiveHeader.cpp
@@ -89,8 +89,7 @@ TEST_F(ConnectionReceiveHeaderTest, RecvReturnedZero)
 
 	connectionReceiveHeader(server, dummyFd, connection);
 
-	EXPECT_EQ(connection.m_buffer, "");
-	EXPECT_EQ(connection.m_bytesReceived, 0);
+	EXPECT_EQ(connection.m_buffer.size(), 0);
 	EXPECT_EQ(connection.m_status, Connection::Closed);
 }
 

--- a/test/test_connectionSendResponse.cpp
+++ b/test/test_connectionSendResponse.cpp
@@ -19,7 +19,6 @@ protected:
 
 		connection.m_timeSinceLastEvent = 0;
 		connection.m_buffer = response;
-		connection.m_bytesReceived = 123;
 		connection.m_status = Connection::SendResponse;
 	}
 	~ConnectionSendResponseTest() override { }
@@ -41,8 +40,7 @@ TEST_F(ConnectionSendResponseTest, SendFullResponseKeepAlive)
 
 	connectionSendResponse(server, dummyFd, connection);
 
-	EXPECT_EQ(connection.m_buffer, "");
-	EXPECT_EQ(connection.m_bytesReceived, 0);
+	EXPECT_EQ(connection.m_buffer.size(), 0);
 	EXPECT_EQ(connection.m_timeSinceLastEvent, std::time(0));
 	EXPECT_EQ(connection.m_status, Connection::Idle);
 }
@@ -56,7 +54,6 @@ TEST_F(ConnectionSendResponseTest, SendFullResponseCloseConnection)
 	connectionSendResponse(server, dummyFd, connection);
 
 	EXPECT_EQ(connection.m_buffer, response);
-	EXPECT_EQ(connection.m_bytesReceived, 123);
 	EXPECT_EQ(connection.m_timeSinceLastEvent, 0);
 	EXPECT_EQ(connection.m_status, Connection::Closed);
 }
@@ -72,7 +69,6 @@ TEST_F(ConnectionSendResponseTest, SendPartialResponse)
 	connectionSendResponse(server, dummyFd, connection);
 
 	EXPECT_EQ(connection.m_buffer, partialResponse);
-	EXPECT_EQ(connection.m_bytesReceived, 123);
 	EXPECT_EQ(connection.m_timeSinceLastEvent, std::time(0));
 	EXPECT_EQ(connection.m_status, Connection::SendResponse);
 }
@@ -84,7 +80,6 @@ TEST_F(ConnectionSendResponseTest, SendFail)
 	connectionSendResponse(server, dummyFd, connection);
 
 	EXPECT_EQ(connection.m_buffer, response);
-	EXPECT_EQ(connection.m_bytesReceived, 123);
 	EXPECT_EQ(connection.m_timeSinceLastEvent, 0);
 	EXPECT_EQ(connection.m_status, Connection::Closed);
 }


### PR DESCRIPTION
### Summary

1. Fixes issue with binary data (e.g. image.png) being corrupted when sent in response
2. Removes unnecessary optimization
3. Prepares for variable sized clientHeader / Body buffer
4. Removes m_receivedBytes from connection

### 1. Binary data

- ResponseBuilder has a static stringstream which contains response header and body
- Binary data was corrupted probably because body was added via << operator to the stream
- solution: only use stringstream for headers, as only for them conversions are needed (e.g. size for content-size)
- image.png can now be sent.
- cgi should not need zero terminator anymore

### 2 Unnecessary optimization

- Stringstream is reused, so that it's only constructed once
- It was also used in a unnecessary efficient way by using a c_str() "hack" (see #20 for more details)
- now just clear the stream like normal people to avoid additional problems
- if really needed optimization can be put back in    

### 3. Prepare for variable sized buffers

- we talked about using std::string as buffer may not be optimal as the container is made for c strings (with zero terminator as delimiter). For example `std::string += char[]` invokes a strlen() for the char array which is problematic for binary data
- more "appropriate" would be std::vector< char >; looked at it, would prob require a bigger rewrite
- left connection buffer as std::string 
- changed local buffer to use a std::vector< char >, so it can be resized (variable array is an C99 extension). At first wanted to also use std::string. But .clear() is not guarenteed to not reallocate
- use explicit .append(start, size) method to append to connection buffer

### 4. Remove receivedBytes

- class Connection had variable receivedBytes
- Wasn't really used, as receivedBytes is the same as buffer.size(). Therefore removed.