### PR TITLE
78 reject not allowed method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ TEST_SRC :=	test_acceptConnections.cpp \
 			test_connectionReceiveHeader.cpp \
 			test_connectionSendResponse.cpp \
 			test_createVirtualServer.cpp \
+			test_handleCompleteRequestHeader.cpp \
 			test_initVirtualServers.cpp \
 			test_isDuplicateServer.cpp \
 			test_OstreamInserters.cpp \

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -820,10 +820,11 @@ bool isCompleteRequestHeader(const std::string& connectionBuffer)
  * EPOLLOUT.
  * After parsing the header, tries to find the "Host" header field in the request headers. If it exists, it rechecks the
  * server configuration for the connection.
- * Then it tries to find the target resource for the request with Server::findTargetResource().
- * If no Status is still OK, and the request has a body, set to Connection::ReceiveBody and the received request header
- * is deleted from the buffer.
- * Else sets to Connection::BuildResponse and the event is modified to listen to EPOLLOUT.
+ * Then it tries to find the target resource for the request with Server::findTargetResource() which also sets the
+ * active location for the connection.
+ * Checks with found location if method is allowed. If not sets StatusMethodNotAllowed.
+ * If Status is still OK, and the request has a body, set to Connection::ReceiveBody and the received request header is
+ * deleted from the buffer. Else sets to Connection::BuildResponse and the event is modified to listen to EPOLLOUT.
  * @param server The server object.
  * @param clientFd The file descriptor of the client socket.
  * @param connection The connection object.
@@ -852,6 +853,11 @@ void handleCompleteRequestHeader(Server& server, int clientFd, Connection& conne
 	}
 
 	server.findTargetResource(connection, connection.m_request);
+
+	// bool array and method are scoped with enum Method
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+	if (!connection.location->allowedMethods[connection.m_request.method])
+		connection.m_request.httpStatus = StatusMethodNotAllowed;
 
 	if (connection.m_request.httpStatus == StatusOK && connection.m_request.hasBody) {
 		connection.m_status = Connection::ReceiveBody;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -104,20 +104,14 @@ time_t Server::getClientTimeout() const { return m_clientTimeout; }
  *
  * @return std::vector<char>& Client header buffer.
  */
-std::vector<char>& Server::getClientHeaderBuffer()
-{
-	return m_clientHeaderBuffer;
-}
+std::vector<char>& Server::getClientHeaderBuffer() { return m_clientHeaderBuffer; }
 
 /**
  * @brief Getter for client body buffer.
  *
  * @return std::vector<char>& Client body buffer.
  */
-std::vector<char>& Server::getClientBodyBuffer()
-{
-	return m_clientBodyBuffer;
-}
+std::vector<char>& Server::getClientBodyBuffer() { return m_clientBodyBuffer; }
 
 /* ====== SETTERS ====== */
 
@@ -923,8 +917,7 @@ void connectionReceiveBody(Server& server, int clientFd, Connection& connection)
 				LOG_ERROR << ERR_CONTENT_LENGTH;
 				connection.m_status = Connection::BuildResponse;
 				server.modifyEvent(clientFd, EPOLLOUT);
-			}
-			else if (connection.m_buffer.size() == Server::s_clientMaxBodySize) {
+			} else if (connection.m_buffer.size() == Server::s_clientMaxBodySize) {
 				LOG_ERROR << "Maximum allowed client request body size reached from " << connection.m_clientSocket;
 				connection.m_request.httpStatus = StatusRequestEntityTooLarge;
 				connection.m_status = Connection::BuildResponse;

--- a/test/test_handleCompleteRequestHeader.cpp
+++ b/test/test_handleCompleteRequestHeader.cpp
@@ -1,0 +1,84 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "MockEpollWrapper.hpp"
+#include "MockSocketPolicy.hpp"
+#include "Server.hpp"
+#include "StatusCode.hpp"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+class HandleCompleteRequestHeaderTest : public ::testing::Test {
+protected:
+	HandleCompleteRequestHeaderTest()
+		: m_server(m_configFile, m_epollWrapper, m_socketPolicy)
+	{
+		ON_CALL(m_epollWrapper, modifyEvent).WillByDefault(Return(true));
+
+		m_connection.m_timeSinceLastEvent = 0;
+		m_connection.m_status = Connection::ReceiveHeader;
+	}
+	~HandleCompleteRequestHeaderTest() override { }
+
+	ConfigFile m_configFile = createDummyConfig();
+	NiceMock<MockEpollWrapper> m_epollWrapper;
+	MockSocketPolicy m_socketPolicy;
+	Server m_server;
+	Socket m_serverSock = { .host = "127.0.0.1", .port = "8080" };
+
+	Connection m_connection = Connection(m_serverSock, Socket(), m_configFile.servers);
+
+	const int m_dummyFd = 10;
+};
+
+TEST_F(HandleCompleteRequestHeaderTest, GETRequest)
+{
+	m_connection.m_buffer.assign("GET / HTTP/1.1\r\nHost:example.com\r\n\r\n");
+
+	handleCompleteRequestHeader(m_server, m_dummyFd, m_connection);
+
+	EXPECT_EQ(m_connection.m_request.httpStatus, StatusOK);
+	EXPECT_EQ(m_connection.m_status, Connection::BuildResponse);
+}
+
+TEST_F(HandleCompleteRequestHeaderTest, NotAllowedMethod)
+{
+	m_connection.m_buffer.assign("POST / HTTP/1.1\r\nHost:example.com\r\n\r\n");
+
+	handleCompleteRequestHeader(m_server, m_dummyFd, m_connection);
+
+	EXPECT_EQ(m_connection.m_request.httpStatus, StatusMethodNotAllowed);
+	EXPECT_EQ(m_connection.m_status, Connection::BuildResponse);
+}
+
+TEST_F(HandleCompleteRequestHeaderTest, POSTRequest)
+{
+	m_connection.m_buffer.assign("POST / HTTP/1.1\r\nHost:example.com\r\nContent-Length:12\r\n\r\nThis is body");
+	m_configFile.servers[0].locations[0].allowedMethods[MethodPost] = true;
+
+	handleCompleteRequestHeader(m_server, m_dummyFd, m_connection);
+
+	EXPECT_EQ(m_connection.m_status, Connection::ReceiveBody);
+	EXPECT_EQ(m_connection.m_buffer, "This is body");
+}
+
+TEST_F(HandleCompleteRequestHeaderTest, ParseFail)
+{
+	m_connection.m_buffer.assign("Wrong");
+
+	handleCompleteRequestHeader(m_server, m_dummyFd, m_connection);
+
+	EXPECT_EQ(m_connection.m_status, Connection::BuildResponse);
+}
+
+TEST_F(HandleCompleteRequestHeaderTest, ConfigFileRandomlyDestroyed)
+{
+	m_connection.m_buffer.assign("GET / HTTP/1.1\r\nHost:example.com\r\n\r\n");
+	m_configFile.servers.clear();
+
+	handleCompleteRequestHeader(m_server, m_dummyFd, m_connection);
+
+	EXPECT_EQ(m_connection.m_request.httpStatus, StatusOK);
+	EXPECT_EQ(m_connection.m_status, Connection::Closed);
+}


### PR DESCRIPTION
- Add simple check if method is allowed 

In `handleCompleteRequestHeader()` after location has been found. Since we have bool array we can just use method enum. If not allowed sets status to `StatusMethodNotAllowed`. Also added test for `handleCompleteRequestHeader()`

This only works if #30 is implemented: a connection should always have an assigned server (default server), it should also have a default location (default location)

- misc: formatting

Saved Server.cpp and it made some changes to formatting -> function one-liners into more-liners