### PR TITLE
89 sending multiple requests on same connection not processed correctly

### DIFF
--- a/src/CGIHandler.cpp
+++ b/src/CGIHandler.cpp
@@ -58,10 +58,10 @@ CGIHandler::CGIHandler(Connection& connection, const ProcessOps& processOps)
 
 	/* ========= Set up environment for CGI script ========= */
 
-	if (connection.m_request.headers.find("Content-Length") != connection.m_request.headers.end())
-		m_env.push_back("CONTENT_LENGTH=" + connection.m_request.headers.at("Content-Length"));
-	if (connection.m_request.headers.find("Content-Type") != connection.m_request.headers.end())
-		m_env.push_back("CONTENT_TYPE=" + connection.m_request.headers.at("Content-Type"));
+	if (connection.m_request.headers.find("content-length") != connection.m_request.headers.end())
+		m_env.push_back("CONTENT_LENGTH=" + connection.m_request.headers.at("content-length"));
+	if (connection.m_request.headers.find("content-type") != connection.m_request.headers.end())
+		m_env.push_back("CONTENT_TYPE=" + connection.m_request.headers.at("content-type"));
 	m_env.push_back("GATEWAY_INTERFACE=CGI/1.1");
 	const std::string pathInfo = extractPathInfo(connection.m_request.uri.path);
 	m_env.push_back("PATH_INFO=" + pathInfo);

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -478,7 +478,7 @@ void RequestParser::parseNonChunkedBody(HTTPRequest& request)
 		length += static_cast<long>(body.size());
 		request.body += body;
 	}
-	const long contentLength = std::strtol(request.headers.at("Content-Length").c_str(), NULL, constants::g_decimalBase);
+	const long contentLength = std::strtol(request.headers.at("content-length").c_str(), NULL, constants::g_decimalBase);
 	if (contentLength != length) {
 		request.httpStatus = StatusBadRequest;
 		throw std::runtime_error(ERR_CONTENT_LENGTH);

--- a/test/test_CGIHandler.cpp
+++ b/test/test_CGIHandler.cpp
@@ -23,8 +23,8 @@ protected:
 
 		request.uri.path = "/cgi-bin/test.py/some/more/path";
 		request.uri.query = "name=John&age=25";
-		request.headers["Content-Length"] = "20";
-		request.headers["Content-Type"] = "text/plain";
+		request.headers["content-length"] = "20";
+		request.headers["content-type"] = "text/plain";
 		request.method = MethodPost;
 
 		location.cgiExt = ".py";

--- a/test/test_parseBody.cpp
+++ b/test/test_parseBody.cpp
@@ -32,7 +32,7 @@ TEST_F(ParseBodyTest, ChunkedBody)
 TEST_F(ParseBodyTest, NonChunkedBodySize14)
 {
 	// Arrange
-	request.headers["Content-Length"] = "14";
+	request.headers["content-length"] = "14";
 
 	// Act
 	p.parseBody("hello \r\nworld!", request);
@@ -44,7 +44,7 @@ TEST_F(ParseBodyTest, NonChunkedBodySize14)
 TEST_F(ParseBodyTest, NonChunkedBodySize16)
 {
 	// Arrange
-	request.headers["Content-Length"] = "16";
+	request.headers["content-length"] = "16";
 
 	// Act
 	p.parseBody("hello \r\nworld!\r\n", request);
@@ -76,7 +76,7 @@ TEST_F(ParseBodyTest, DifferingChunkSize)
 TEST_F(ParseBodyTest, DifferingContentLength)
 {
 	// Arrange
-	request.headers["Content-Length"] = "3";
+	request.headers["content-length"] = "3";
 
 	// Act & Assert
 	EXPECT_THROW(


### PR DESCRIPTION
## Overview
After merge with main the request headers were all stored in lower case. This caused errors throughout the code where the headers were searched for with initial upper case letters, eventually resulting in a broken chain of processing multiple requests involving a CGI POST request.

All instances invoking the headers map are performed now in lower case. The observed behaviour has resumed expectations allowing multiple requests be sent and processed correctly.

closes #89 
closes #77 