### PR TITLE
33 always close connection if a bad request 400 is detected

### DIFF
--- a/inc/ResponseBuilder.hpp
+++ b/inc/ResponseBuilder.hpp
@@ -28,7 +28,7 @@ public:
 private:
 	void appendStatusLine(const HTTPRequest& request);
 	void appendHeaders(const HTTPRequest& request);
-	void appendHeadersCGI();
+	void appendHeadersCGI(const HTTPRequest& request);
 	std::string getMIMEType(const std::string& extension);
 	void initMIMETypes();
 	void resetBuilder();

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -49,7 +49,7 @@ void ResponseBuilder::buildResponse(Connection& connection)
 
 	appendStatusLine(request);
 	if (request.hasCGI && request.httpStatus == StatusOK)
-		appendHeadersCGI();
+		appendHeadersCGI(request);
 	else
 		appendHeaders(request);
 
@@ -115,6 +115,11 @@ void ResponseBuilder::appendHeaders(const HTTPRequest& request)
 	if (iter != request.headers.end()) {
 		m_responseHeader << "Location: " << iter->second << "\r\n";
 	}
+	// Connection
+	if (request.shallCloseConnection)
+		m_responseHeader << "Connection: close\r\n";
+	else
+		m_responseHeader << "Connection: keep-alive\r\n";
 	// Delimiter
 	m_responseHeader << "\r\n";
 }
@@ -127,8 +132,9 @@ void ResponseBuilder::appendHeaders(const HTTPRequest& request)
  * Server: TriHard.
  * Date: Current date in GMT.
  * Location: Target resource if status is StatusMovedPermanently.
+ * @param request HTTP request.
  */
-void ResponseBuilder::appendHeadersCGI()
+void ResponseBuilder::appendHeadersCGI(const HTTPRequest& request)
 {
 	// Content-Length
 	m_responseHeader << "Content-Length: " << m_responseBody.length() << "\r\n";
@@ -136,6 +142,11 @@ void ResponseBuilder::appendHeadersCGI()
 	m_responseHeader << "Server: TriHard\r\n";
 	// Date
 	m_responseHeader << "Date: " << webutils::getGMTString(time(0), "%a, %d %b %Y %H:%M:%S GMT") << "\r\n";
+	// Connection
+	if (request.shallCloseConnection)
+		m_responseHeader << "Connection: close\r\n";
+	else
+		m_responseHeader << "Connection: keep-alive\r\n";
 }
 
 /**

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1153,6 +1153,7 @@ bool isCompleteBody(Connection& connection)
 			LOG_ERROR << ERR_CONTENT_LENGTH;
 			LOG_ERROR << "Content-Length: " << contentLength << ", Buffer size: " << connection.m_buffer.size();
 			connection.m_request.httpStatus = StatusBadRequest;
+			connection.m_request.shallCloseConnection = true;
 			return false;
 		}
 		if (contentLength == connection.m_buffer.size())

--- a/test/test_parseHeader_Headers.cpp
+++ b/test/test_parseHeader_Headers.cpp
@@ -166,6 +166,7 @@ TEST_F(ParseHeadersTest, WhitespaceBetweenHeaderFieldNameAndColon)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Whitespace between header field-name and colon detected", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -185,6 +186,7 @@ TEST_F(ParseHeadersTest, ObsoleteLineFolding)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Obsolete line folding detected", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -204,6 +206,7 @@ TEST_F(ParseHeadersTest, InvalidFieldName)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid char in header field name", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -223,6 +226,7 @@ TEST_F(ParseHeadersTest, EmptyContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid content-length provided", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -242,6 +246,7 @@ TEST_F(ParseHeadersTest, InvalidContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid content-length provided", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -261,6 +266,7 @@ TEST_F(ParseHeadersTest, RepeatedNonEqualContentLengths)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Multiple differing content-length values", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -280,6 +286,7 @@ TEST_F(ParseHeadersTest, InvalidInFirstRepeatedContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid content-length provided", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -299,6 +306,7 @@ TEST_F(ParseHeadersTest, InvalidInLastRepeatedContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid content-length provided", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -318,6 +326,7 @@ TEST_F(ParseHeadersTest, RepeatedContentLengthHeaders)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Multiple differing content-length values", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -337,6 +346,7 @@ TEST_F(ParseHeadersTest, EmptyTransferEncoding)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Transfer encoding not detected", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -356,6 +366,7 @@ TEST_F(ParseHeadersTest, InvalidChunkedTransferEncodingPositioning)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Chunked encoding not the final encoding", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -393,6 +404,7 @@ TEST_F(ParseHeadersTest, MissingHostHeader)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Missing host header", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -411,6 +423,7 @@ TEST_F(ParseHeadersTest, EmptyHostValue)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Missing hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -430,6 +443,7 @@ TEST_F(ParseHeadersTest, MultipleHostHeaders)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Multiple host headers", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -448,6 +462,7 @@ TEST_F(ParseHeadersTest, HostnameInvalidChar)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -466,6 +481,7 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtStart)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -484,6 +500,7 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtStartOfLabel)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -502,6 +519,7 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtEndOfLabel)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -520,6 +538,7 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtEnd)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -538,6 +557,7 @@ TEST_F(ParseHeadersTest, HostnameLabelTooLong)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -556,6 +576,7 @@ TEST_F(ParseHeadersTest, HostnameTooLong)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -574,6 +595,7 @@ TEST_F(ParseHeadersTest, HostnameAsIPInvalid)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid IP as hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -593,6 +615,7 @@ TEST_F(ParseHeadersTest, InvalidHostnameLikeIP)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid IP as hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -612,6 +635,7 @@ TEST_F(ParseHeadersTest, InvalidHostnameLikeIP2)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid IP as hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -630,6 +654,7 @@ TEST_F(ParseHeadersTest, HostnameAsIPWithInvalidPort)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: Invalid IP with port as hostname", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},

--- a/test/test_parseHeader_RequestLine.cpp
+++ b/test/test_parseHeader_RequestLine.cpp
@@ -154,6 +154,7 @@ TEST_F(ParseRequestLineTest, MissingSpace)
 				p.parseHeader("GET/search?query=openai&year=2024#conclusion HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: missing single space", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -171,6 +172,7 @@ TEST_F(ParseRequestLineTest, MissingSlash)
 				p.parseHeader("GET search?query=openai&year=2024#conclusion HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: missing slash in URI", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -188,6 +190,7 @@ TEST_F(ParseRequestLineTest, DoubleQuestionMark)
 				p.parseHeader("GET /search?? HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid char in URI", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -205,6 +208,7 @@ TEST_F(ParseRequestLineTest, DoubleHash)
 				p.parseHeader("GET /search?## HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid char in URI", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -222,6 +226,7 @@ TEST_F(ParseRequestLineTest, URI_InvalidChar)
 				p.parseHeader("GET /search§blabla/index.html HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid char in URI", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -239,6 +244,7 @@ TEST_F(ParseRequestLineTest, URI_MissingSpace)
 				p.parseHeader("GET /searchHTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid char in URI", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -256,6 +262,7 @@ TEST_F(ParseRequestLineTest, Version_MissingH)
 				p.parseHeader("GET /search.html TTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid format of version", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -273,6 +280,7 @@ TEST_F(ParseRequestLineTest, Version_MissingSlash)
 				p.parseHeader("GET /search.html HTTP1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid format of version", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -290,6 +298,7 @@ TEST_F(ParseRequestLineTest, Version_InvalidMajor)
 				p.parseHeader("GET /search.html HTTP/x.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid version major", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -307,6 +316,7 @@ TEST_F(ParseRequestLineTest, Version_MissingDot)
 				p.parseHeader("GET /search.html HTTP/11\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid version delimiter", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -324,6 +334,7 @@ TEST_F(ParseRequestLineTest, Version_InvalidMinor)
 				p.parseHeader("GET /search.html HTTP/1.x\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ("Invalid HTTP request: invalid version minor", e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},


### PR DESCRIPTION
## Overview

Sets flag _shallCloseConnection_ to true whenever the received HTTP request does not correspond to the message grammar set in RFC 9112 and the server is supposed to respond with a 400 Bad request before closing the connection. Added header _Connection_ in the response: if _shallCloseConnection = true_, then Connection: close is sent, otherwise Connection: keep-alive.

Tests adapted to reflect the boolean being set.

To verify in which cases the connection shall be closed, an examination of the various response codes was also undertaken. No deviation from the current implementation was found.

closes #33 
closes #74 