### PR TITLE
133 filewritehandler does not set statusforbidden

### DIFF
--- a/inc/FileWriteHandler.hpp
+++ b/inc/FileWriteHandler.hpp
@@ -17,7 +17,7 @@ class FileWriteHandler {
 
 public:
 	explicit FileWriteHandler(const FileSystemPolicy& fileSystemPolicy);
-	std::string execute(const std::string& path, const std::string& content);
+	std::string execute(const std::string& path, const std::string& content, statusCode& httpStatus);
 
 private:
 	const FileSystemPolicy& m_fileSystemPolicy;

--- a/src/DeleteHandler.cpp
+++ b/src/DeleteHandler.cpp
@@ -17,13 +17,13 @@ DeleteHandler::DeleteHandler(const FileSystemPolicy& fileSystemPolicy)
  * - Delete a regular file and return a success message.
  * - Delete a directory and return a success message.
  * - Set the HTTP status to 404 if the file does not exist.
- * - Set the HTTP status to 500 if the file type is not supported.
- * - Set the HTTP status to 403 if the operation is not permitted.
+ * - Set the HTTP status to 403 if the file type is not supported or if the operation is not permitted.
+ * - Set the HTTP status to 500 if an error while calling a function occurs.
  *
  * @param path The path of the file or directory to delete.
  * @param httpStatus Reference to the HTTP status code to be set based on the operation result.
  * @return A JSON string containing the result of the delete operation.
- * @todo use custom exception
+ * @todo reactivate deleteDirectory after eval.
  */
 std::string DeleteHandler::execute(const std::string& path, statusCode& httpStatus)
 {

--- a/src/FileWriteHandler.cpp
+++ b/src/FileWriteHandler.cpp
@@ -55,6 +55,10 @@ std::string FileWriteHandler::execute(const std::string& path, const std::string
 	} catch (FileSystemPolicy::NoPermissionException& e) {
 		LOG_ERROR << e.what();
 		httpStatus = StatusForbidden;
+	} catch (FileSystemPolicy::FileNotFoundException& e) {
+		LOG_ERROR << e.what();
+		LOG_ERROR << "Missing directory in path " << path;
+		httpStatus = StatusNotFound;
 	} catch (std::runtime_error& e) {
 		LOG_ERROR << e.what();
 		LOG_ERROR << "Failed to write data to the file: " << path;

--- a/src/FileWriteHandler.cpp
+++ b/src/FileWriteHandler.cpp
@@ -19,13 +19,14 @@ FileWriteHandler::FileWriteHandler(const FileSystemPolicy& fileSystemPolicy)
  *
  * @param path The file path where the content should be written.
  * @param content The content to be written to the file.
+ * @param httpStatus Reference to the HTTP status code to be set based on the operation result.
  * @return A JSON-formatted string containing the operation result, including the file path, file size,
  *         last modified time, and status (either "updated" or "created"). If an error occurs, an empty
  *         string is returned.
  *
  * @exception std::runtime_error If an error occurs during the file operation.
  */
-std::string FileWriteHandler::execute(const std::string& path, const std::string& content)
+std::string FileWriteHandler::execute(const std::string& path, const std::string& content, statusCode& httpStatus)
 {
 	try {
 		const bool isExistingFile = m_fileSystemPolicy.isExistingFile(path);
@@ -42,6 +43,7 @@ std::string FileWriteHandler::execute(const std::string& path, const std::string
 					   << "\"status\": \"updated\"\n"
 					   << "}\n";
 		} else {
+			httpStatus = StatusCreated;
 			m_response << "{\n"
 					   << "\"message\": \"File created successfully\",\n"
 					   << "\"file\": \"" << path << "\",\n"
@@ -50,10 +52,13 @@ std::string FileWriteHandler::execute(const std::string& path, const std::string
 					   << "\"status\": \"created\"\n"
 					   << "}\n";
 		}
-		return m_response.str();
+	} catch (FileSystemPolicy::NoPermissionException& e) {
+		LOG_ERROR << e.what();
+		httpStatus = StatusForbidden;
 	} catch (std::runtime_error& e) {
 		LOG_ERROR << e.what();
 		LOG_ERROR << "Failed to write data to the file: " << path;
-		return "";
+		httpStatus = StatusInternalServerError;
 	}
+	return m_response.str();
 }

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -87,15 +87,11 @@ void ResponseBodyHandler::execute()
 
 	if (m_request.method == MethodPost) {
 		FileWriteHandler fileWriteHandler(m_fileSystemPolicy);
-		m_responseBody = fileWriteHandler.execute(m_request.targetResource, m_request.body);
-		if (m_responseBody.find("created") != std::string::npos) {
-			m_request.httpStatus = StatusCreated;
+		m_responseBody = fileWriteHandler.execute(m_request.targetResource, m_request.body, m_request.httpStatus);
+		if (m_request.httpStatus == StatusCreated)
 			m_request.headers["location"] = m_request.uri.path;
-		}
-		if (m_responseBody.empty()) {
-			m_request.httpStatus = StatusInternalServerError;
+		if (m_responseBody.empty())
 			handleErrorBody();
-		}
 		m_request.targetResource = "posted.json";
 		return;
 	}

--- a/test/integration/server_response/test_POST.py
+++ b/test/integration/server_response/test_POST.py
@@ -18,6 +18,25 @@ def test_POST_simple():
     # Delete created file
     os.remove(dst_file_path)
 
+def test_POST_append():
+    print("Request for /uploads/existing_file.txt")
+    # Body to send
+    existing_content = "Hello, World!\n"
+    payload = "It is me!"
+    dst_file_path = "/workspaces/webserv/html/uploads/existing_file.txt"
+    with open(dst_file_path, "w") as file:
+        file.write(existing_content)
+
+    response = requests.post("http://localhost:8080/uploads/existing_file.txt", data=payload)
+
+    assert response.status_code == 200
+    # Check if file was appended correctly
+    with open(dst_file_path, "r") as file:
+        content = file.read()
+        assert content.find(existing_content + payload) == 0
+    # Delete created file
+    os.remove(dst_file_path)
+
 # For encoding chunked
 # sa https://requests.readthedocs.io/en/latest/user/advanced/#chunk-encoded-requests
 def generate_chunks():

--- a/test/integration/server_response/test_error.py
+++ b/test/integration/server_response/test_error.py
@@ -39,3 +39,28 @@ def test_directory_no_autoindex():
     print("Request for directory without autoindex")
     response = requests.get("http://localhost:8080/css/")
     assert response.status_code == 403
+
+def test_no_permission_to_append():
+    print("Chmod 000 existing_file and try to append")
+    # Body to send
+    existing_content = "Hello, World!\n"
+    payload = "It is me!"
+    dst_file_path = "/workspaces/webserv/html/uploads/existing_file.txt"
+    with open(dst_file_path, "w") as file:
+        file.write(existing_content)
+    original_permissions = stat.S_IMODE(os.stat(dst_file_path).st_mode)
+    # Change permissions to 000
+    os.chmod(dst_file_path, 0o000)
+
+    response = requests.post("http://localhost:8080/uploads/existing_file.txt", data=payload)
+
+    # Restore the original permissions
+    os.chmod(dst_file_path, original_permissions)
+
+    assert response.status_code == 403
+    # Check if file was not appended
+    with open(dst_file_path, "r") as file:
+        content = file.read()
+        assert content.find(payload) == -1
+    # Delete created file
+    os.remove(dst_file_path)

--- a/test/integration/server_response/test_error.py
+++ b/test/integration/server_response/test_error.py
@@ -64,3 +64,11 @@ def test_no_permission_to_append():
         assert content.find(payload) == -1
     # Delete created file
     os.remove(dst_file_path)
+
+def test_missing_dir_in_path():
+    print("Request to /workspaces/webserv/html/uploads/not_exist/upload.txt")
+    payload = "Hello World!"
+
+    response = requests.post("http://localhost:8080/uploads/not_exist/upload.txt", data=payload)
+
+    assert response.status_code == 404

--- a/test/unit/test_FileWriteHandler.cpp
+++ b/test/unit/test_FileWriteHandler.cpp
@@ -95,3 +95,17 @@ TEST_F(FileWriteHandlerTest, NoPermission)
 	EXPECT_EQ(responseBody, "");
 	EXPECT_EQ(m_httpStatus, StatusForbidden);
 }
+
+TEST_F(FileWriteHandlerTest, FileNotFound)
+{
+	// Arrange
+	EXPECT_CALL(m_fileSystemPolicy, writeToFile)
+	.WillOnce(testing::Throw(FileSystemPolicy::FileNotFoundException("File not found")));
+
+	// Act
+	std::string responseBody = m_fileWriteHandler.execute(m_path, m_content, m_httpStatus);
+
+	// Assert
+	EXPECT_EQ(responseBody, "");
+	EXPECT_EQ(m_httpStatus, StatusNotFound);
+}


### PR DESCRIPTION
Fixes bug as described in #133.

FileWriteHandler and DeleteHandler now behave more similar: they get passed statusCode and set it themselves. FileWriteHandler also catches NoPermissionException.

Added unit and integration test cases