### PR TITLE
126 status 405 response should include allow header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ TEST_SRC :=	test_acceptConnections.cpp \
 			test_registerConnection.cpp \
 			test_registerVirtualServer.cpp \
 			test_ResponseBodyHandler.cpp \
+			test_ResponseBuilder.cpp \
 			test_selectServerConfig.cpp \
 			test_SocketPolicy_retrieveSocketInfo.cpp \
 			test_shutdownServer.cpp \

--- a/inc/ResponseBodyHandler.hpp
+++ b/inc/ResponseBodyHandler.hpp
@@ -38,3 +38,4 @@ private:
 };
 
 std::string getDefaultErrorPage(statusCode status);
+std::string constructAllowHeader(const bool (&allowedMethods)[MethodCount]);

--- a/inc/ResponseBuilder.hpp
+++ b/inc/ResponseBuilder.hpp
@@ -33,6 +33,7 @@ private:
 	std::string getMIMEType(const std::string& extension);
 	void initMIMETypes();
 	void resetBuilder();
+	void setHeaderForStatusCode(const HTTPRequest& request, const bool (&allowedMethods)[MethodCount]);
 	bool checkForExistingHeader(const std::string& headerName);
 
 	std::map<std::string, std::string> m_mimeTypes;
@@ -41,3 +42,5 @@ private:
 	std::string m_responseBody;
 	std::map<std::string, std::string> m_responseHeaders;
 };
+
+std::string constructAllowHeader(const bool (&allowedMethods)[MethodCount]);

--- a/inc/ResponseBuilder.hpp
+++ b/inc/ResponseBuilder.hpp
@@ -33,7 +33,6 @@ private:
 	std::string getMIMEType(const std::string& extension);
 	void initMIMETypes();
 	void resetBuilder();
-	void setHeaderForStatusCode(const HTTPRequest& request, const bool (&allowedMethods)[MethodCount]);
 	bool checkForExistingHeader(const std::string& headerName);
 
 	std::map<std::string, std::string> m_mimeTypes;
@@ -42,5 +41,3 @@ private:
 	std::string m_responseBody;
 	std::map<std::string, std::string> m_responseHeaders;
 };
-
-std::string constructAllowHeader(const bool (&allowedMethods)[MethodCount]);

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -129,8 +129,8 @@ void ResponseBodyHandler::parseCGIResponseHeaders()
 	const size_t posHeadersEnd = m_responseBody.find("\r\n\r\n");
 	// Include one CRLF at the end of last header line
 	std::string headers = m_responseBody.substr(0, posHeadersEnd + sizeCRLF);
-    std::string loweredHeaders = headers;
-    webutils::lowercase(loweredHeaders);
+	std::string loweredHeaders = headers;
+	webutils::lowercase(loweredHeaders);
 
 	if (posHeadersEnd == std::string::npos) {
 		m_request.httpStatus = StatusInternalServerError;
@@ -139,7 +139,8 @@ void ResponseBodyHandler::parseCGIResponseHeaders()
 		return;
 	}
 
-	if (loweredHeaders.find("content-type: ") == std::string::npos && loweredHeaders.find("location: ") == std::string::npos
+	if (loweredHeaders.find("content-type: ") == std::string::npos
+		&& loweredHeaders.find("location: ") == std::string::npos
 		&& loweredHeaders.find("status: ") == std::string::npos) {
 		m_request.httpStatus = StatusInternalServerError;
 		handleErrorBody();

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -35,6 +35,9 @@ ResponseBodyHandler::ResponseBodyHandler(Connection& connection, std::string& re
  */
 void ResponseBodyHandler::execute()
 {
+	if (isRedirectionStatus(m_request.httpStatus))
+		m_responseHeaders["location"] = m_request.targetResource;
+
 	if (m_request.hasReturn) {
 		const bool isEmpty = m_request.targetResource.empty();
 		if (isEmpty && m_request.httpStatus < StatusMovedPermanently)

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -38,6 +38,9 @@ void ResponseBodyHandler::execute()
 	if (isRedirectionStatus(m_request.httpStatus))
 		m_responseHeaders["location"] = m_request.targetResource;
 
+	if (m_request.httpStatus == StatusMethodNotAllowed)
+		m_responseHeaders["allow"] = constructAllowHeader(m_connection.location->allowedMethods);
+
 	if (m_request.hasReturn) {
 		const bool isEmpty = m_request.targetResource.empty();
 		if (isEmpty && m_request.httpStatus < StatusMovedPermanently)
@@ -411,4 +414,29 @@ std::string getDefaultErrorPage(statusCode statusCode)
 
 	ret += errorTail;
 	return (ret);
+}
+
+/**
+ * @brief Construct Allow header.
+ *
+ * Constructs the Allow header based on the allowed methods. Methods are appended with ", " at the end to easily join
+ * them. If at the end at least one method was appended, the last ", " is removed.
+ * If no methods were appended, an empty string is returned.
+ * @param allowedMethods Array of allowed methods.
+ * @return std::string Constructed Allow header.
+ */
+std::string constructAllowHeader(const bool (&allowedMethods)[MethodCount])
+{
+	std::string allowHeader;
+
+	if (allowedMethods[MethodGet])
+		allowHeader.append("GET, ");
+	if (allowedMethods[MethodPost])
+		allowHeader.append("POST, ");
+	if (allowedMethods[MethodDelete])
+		allowHeader.append("DELETE, ");
+
+	if (!allowHeader.empty())
+		allowHeader.erase(allowHeader.size() - 2, 2);
+	return allowHeader;
 }

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -35,9 +35,6 @@ ResponseBodyHandler::ResponseBodyHandler(Connection& connection, std::string& re
  */
 void ResponseBodyHandler::execute()
 {
-	if (isRedirectionStatus(m_request.httpStatus))
-		m_responseHeaders["location"] = m_request.targetResource;
-
 	if (m_request.hasReturn) {
 		const bool isEmpty = m_request.targetResource.empty();
 		if (isEmpty && m_request.httpStatus < StatusMovedPermanently)

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -187,10 +187,10 @@ std::string ResponseBuilder::getMIMEType(const std::string& extension)
 /**
  * @brief Sets specific headers depending on status code of HTTP request.
  *
- * For redirection status (3xx) adds location header.
  * For Method Not Allowed (405) adds allow header.
  * @param request The HTTP request object containing the request details.
  * @param allowedMethods Array of allowed methods.
+ * @todo set headers for other status codes.
  */
 void ResponseBuilder::setHeaderForStatusCode(const HTTPRequest& request, const bool (&allowedMethods)[MethodCount])
 {

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -47,8 +47,6 @@ void ResponseBuilder::buildResponse(Connection& connection)
 	ResponseBodyHandler responseBodyHandler(connection, m_responseBody, m_responseHeaders, m_fileSystemPolicy);
 	responseBodyHandler.execute();
 
-	setHeaderForStatusCode(request, connection.location->allowedMethods);
-
 	appendResponseHeader(request);
 
 	LOG_DEBUG << "Response header: \n" << m_responseHeaderStream.str();
@@ -182,43 +180,4 @@ std::string ResponseBuilder::getMIMEType(const std::string& extension)
 		return iter->second;
 	}
 	return m_mimeTypes.at("default");
-}
-
-/**
- * @brief Sets specific headers depending on status code of HTTP request.
- *
- * For Method Not Allowed (405) adds allow header.
- * @param request The HTTP request object containing the request details.
- * @param allowedMethods Array of allowed methods.
- * @todo set headers for other status codes.
- */
-void ResponseBuilder::setHeaderForStatusCode(const HTTPRequest& request, const bool (&allowedMethods)[MethodCount])
-{
-	if (request.httpStatus == StatusMethodNotAllowed)
-		m_responseHeaders["allow"] = constructAllowHeader(allowedMethods);
-}
-
-/**
- * @brief Construct Allow header.
- *
- * Constructs the Allow header based on the allowed methods. Methods are appended with ", " at the end to easily join
- * them. If at the end at least one method was appended, the last ", " is removed.
- * If no methods were appended, an empty string is returned.
- * @param allowedMethods Array of allowed methods.
- * @return std::string Constructed Allow header.
- */
-std::string constructAllowHeader(const bool (&allowedMethods)[MethodCount])
-{
-	std::string allowHeader;
-
-	if (allowedMethods[MethodGet])
-		allowHeader.append("GET, ");
-	if (allowedMethods[MethodPost])
-		allowHeader.append("POST, ");
-	if (allowedMethods[MethodDelete])
-		allowHeader.append("DELETE, ");
-
-	if (!allowHeader.empty())
-		allowHeader.erase(allowHeader.size() - 2, 2);
-	return allowHeader;
 }

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -194,9 +194,6 @@ std::string ResponseBuilder::getMIMEType(const std::string& extension)
  */
 void ResponseBuilder::setHeaderForStatusCode(const HTTPRequest& request, const bool (&allowedMethods)[MethodCount])
 {
-	if (isRedirectionStatus(request.httpStatus))
-		m_responseHeaders["location"] = request.targetResource;
-
 	if (request.httpStatus == StatusMethodNotAllowed)
 		m_responseHeaders["allow"] = constructAllowHeader(allowedMethods);
 }

--- a/test/integration/server_response/test_error.py
+++ b/test/integration/server_response/test_error.py
@@ -72,3 +72,12 @@ def test_missing_dir_in_path():
     response = requests.post("http://localhost:8080/uploads/not_exist/upload.txt", data=payload)
 
     assert response.status_code == 404
+
+def test_method_not_allowed():
+    print("Request to /")
+    payload = "Hello World!"
+
+    response = requests.post("http://localhost:8080/", data=payload)
+
+    assert response.status_code == 405
+    assert response.headers["allow"] == "GET"

--- a/test/unit/test_ResponseBuilder.cpp
+++ b/test/unit/test_ResponseBuilder.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "MockFileSystemPolicy.hpp"
+#include "ResponseBuilder.hpp"
+
+ConfigFile createTestConfigfile();
+
+using ::testing::Return;
+using ::testing::HasSubstr;
+
+class ResponseBuilderTest : public ::testing::Test {
+	protected:
+	ResponseBuilderTest()
+	{
+
+	}
+	~ResponseBuilderTest() override { }
+
+	const int m_dummyFd = 10;
+	Socket m_serverSock = { .host = "127.0.0.1", .port = "8080" };
+	ConfigFile m_configFile = createTestConfigfile();
+	Connection m_connection = Connection(m_serverSock, Socket(), m_dummyFd, m_configFile.servers);
+
+	HTTPRequest& m_request = m_connection.m_request;
+
+	std::string m_responseBody;
+	std::map<std::string, std::string> m_responseHeaders;
+	MockFileSystemPolicy m_fileSystemPolicy;
+	ResponseBuilder m_responseBuilder = ResponseBuilder(m_fileSystemPolicy);
+};
+
+TEST_F(ResponseBuilderTest, SimpleResponse)
+{
+	EXPECT_CALL(m_fileSystemPolicy, getFileContents)
+		.WillOnce(Return("content"));
+
+	m_request.method = MethodGet;
+	m_request.targetResource = "/index.html";
+
+	m_responseBuilder.buildResponse(m_connection);
+
+	std::string response = m_responseBuilder.getResponse();
+
+	EXPECT_THAT(response, HasSubstr("HTTP/1.1 200 OK\r\n"));
+	EXPECT_THAT(response, HasSubstr("Content-Type: text/html\r\n"));
+	EXPECT_THAT(response, HasSubstr("Content-Length: 7\r\n"));
+	EXPECT_THAT(response, HasSubstr("Server: TriHard\r\n"));
+	EXPECT_THAT(response, HasSubstr("Date: "));
+	EXPECT_THAT(response, HasSubstr("Connection: keep-alive\r\n"));
+	EXPECT_THAT(response, HasSubstr("\r\n\r\ncontent"));
+}
+
+TEST_F(ResponseBuilderTest, Redirection)
+{
+	m_request.method = MethodGet;
+	m_request.httpStatus = StatusPermanentRedirect;
+	m_request.targetResource = "/redirect.html";
+
+	m_responseBuilder.buildResponse(m_connection);
+
+	std::string response = m_responseBuilder.getResponse();
+
+	EXPECT_THAT(response, HasSubstr("HTTP/1.1 308 Permanent Redirect\r\n"));
+	EXPECT_THAT(response, HasSubstr("Content-Type: text/html\r\n"));
+	EXPECT_THAT(response, HasSubstr("Location: /redirect.html\r\n"));
+	EXPECT_THAT(response, HasSubstr("Connection: keep-alive\r\n"));
+}
+
+TEST_F(ResponseBuilderTest, MethodNotAllowed)
+{
+	m_request.method = MethodGet;
+	m_request.targetResource = "/not_allowed.html";
+	m_request.httpStatus = StatusMethodNotAllowed;
+	m_request.shallCloseConnection = true;
+
+	m_configFile.servers[0].locations[0].allowedMethods[MethodGet] = false;
+	m_configFile.servers[0].locations[0].allowedMethods[MethodPost] = true;
+	m_configFile.servers[0].locations[0].allowedMethods[MethodDelete] = true;
+
+	m_responseBuilder.buildResponse(m_connection);
+
+	std::string response = m_responseBuilder.getResponse();
+
+	EXPECT_THAT(response, HasSubstr("HTTP/1.1 405 Method Not Allowed\r\n"));
+	EXPECT_THAT(response, HasSubstr("Content-Type: text/html\r\n"));
+	EXPECT_THAT(response, HasSubstr("Allow: POST, DELETE\r\n"));
+	EXPECT_THAT(response, HasSubstr("Connection: close\r\n"));
+}


### PR DESCRIPTION
Adds function to construct Allow header (see also #126).

Added unittest and integration test.