### PR TITLE
143 requestparser should act on header connection

### DIFF
--- a/inc/RequestParser.hpp
+++ b/inc/RequestParser.hpp
@@ -63,6 +63,7 @@ private:
 	static void validateNoMultipleHostHeaders(const std::string& headerName, HTTPRequest& request);
 	static void validateTransferEncoding(HTTPRequest& request);
 	static void validateMethodWithBody(HTTPRequest& request);
+    static void validateConnectionHeader(HTTPRequest& request);
 
 	// Helper functions
 	static std::string checkForSpace(const std::string& str, HTTPRequest& request);

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -33,9 +33,8 @@
 #define ERR_INVALID_CONTENT_LENGTH "Invalid HTTP request: Invalid content-length provided"
 #define ERR_NON_FINAL_CHUNKED_ENCODING "Invalid HTTP request: Chunked encoding not the final encoding"
 #define ERR_NON_EXISTENT_TRANSFER_ENCODING "Invalid HTTP request: Transfer encoding not detected"
-#define ERR_EMPTY_CONNECTION_VALUE "Invalid HTTP request: Empty connection value"
-#define ERR_MULTIPLE_CONNECTION_VALUES "Invalid HTTP request: Multiple connection values"
-#define ERR_INVALID_CONNECTION_VALUE "Invalid HTTP request: Invalid connection value"
+#define ERR_EMPTY_CONNECTION_VALUE "Invalid HTTP request: Empty connection header value"
+#define ERR_INVALID_CONNECTION_VALUE "Invalid HTTP request: Invalid connection header value"
 
 // HTTP REQUEST BODY ERRORS
 #define ERR_NON_EXISTENT_CHUNKSIZE "Invalid HTTP request: Chunk size not detected"

--- a/inc/error.hpp
+++ b/inc/error.hpp
@@ -33,6 +33,9 @@
 #define ERR_INVALID_CONTENT_LENGTH "Invalid HTTP request: Invalid content-length provided"
 #define ERR_NON_FINAL_CHUNKED_ENCODING "Invalid HTTP request: Chunked encoding not the final encoding"
 #define ERR_NON_EXISTENT_TRANSFER_ENCODING "Invalid HTTP request: Transfer encoding not detected"
+#define ERR_EMPTY_CONNECTION_VALUE "Invalid HTTP request: Empty connection value"
+#define ERR_MULTIPLE_CONNECTION_VALUES "Invalid HTTP request: Multiple connection values"
+#define ERR_INVALID_CONNECTION_VALUE "Invalid HTTP request: Invalid connection value"
 
 // HTTP REQUEST BODY ERRORS
 #define ERR_NON_EXISTENT_CHUNKSIZE "Invalid HTTP request: Chunk size not detected"

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -789,11 +789,6 @@ void RequestParser::validateConnectionHeader(HTTPRequest& request)
 			request.shallCloseConnection = true;
 			throw std::runtime_error(ERR_EMPTY_CONNECTION_VALUE);
 		}
-		if (iter->second.find(',') != std::string::npos) {
-			request.httpStatus = StatusBadRequest;
-			request.shallCloseConnection = true;
-			throw std::runtime_error(ERR_MULTIPLE_CONNECTION_VALUES);
-		}
 
 		if (iter->second == "close") {
 			request.shallCloseConnection = true;

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -643,7 +643,8 @@ void RequestParser::validateTransferEncoding(HTTPRequest& request)
 		}
 		if (request.headers.find("content-length") != request.headers.end())
 			request.shallCloseConnection = true;
-
+        
+        webutils::lowercase(request.headers.at("transfer-encoding"));
 		if (request.headers.at("transfer-encoding").find("chunked") != std::string::npos) {
 			std::vector<std::string> encodings = webutils::split(request.headers.at("transfer-encoding"), ", ");
 			if (encodings[encodings.size() - 1] != "chunked") {
@@ -782,7 +783,7 @@ void RequestParser::validateConnectionHeader(HTTPRequest& request)
 {
 	LOG_DEBUG << "Validating Connection header...";
 
-	std::map<std::string, std::string>::const_iterator iter = request.headers.find("connection");
+	std::map<std::string, std::string>::iterator iter = request.headers.find("connection");
 	if (iter != request.headers.end()) {
 		if (iter->second.empty()) {
 			request.httpStatus = StatusBadRequest;
@@ -790,6 +791,7 @@ void RequestParser::validateConnectionHeader(HTTPRequest& request)
 			throw std::runtime_error(ERR_EMPTY_CONNECTION_VALUE);
 		}
 
+        webutils::lowercase(iter->second);
 		if (iter->second == "close") {
 			request.shallCloseConnection = true;
 		} else if (iter->second == "keep-alive") {

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -397,6 +397,7 @@ void RequestParser::parseHeaders(HTTPRequest& request)
 	validateHostHeader(request);
 	validateTransferEncoding(request);
 	validateMethodWithBody(request);
+	validateConnectionHeader(request);
 }
 
 /* ====== BODY PARSING ====== */
@@ -762,6 +763,51 @@ void RequestParser::validateNoMultipleHostHeaders(const std::string& headerName,
 			throw std::runtime_error(ERR_MULTIPLE_HOST_HEADERS);
 		}
 	}
+}
+
+/**
+ * @brief Validates the Connection header in an HTTP request.
+ *
+ * This function checks the validity of the Connection header in the provided HTTP request.
+ * It ensures that the header is not empty, does not contain multiple values, and has a valid value.
+ * Valid values for the Connection header are "close" and "keep-alive" where "close" indicates that
+ * the connection should be closed after the response, and "keep-alive" indicates that the connection
+ * should be kept open for further requests. By default the connection is kept alive with shallCloseConnection set to false.
+ * If the header is invalid, it sets the HTTP status to BadRequest and indicates that the connection should be closed.
+ *
+ * @param request The HTTPRequest object containing the request data.
+ * @throws std::runtime_error if the Connection header is empty, contains multiple values, or has an invalid value.
+ */
+void RequestParser::validateConnectionHeader(HTTPRequest& request)
+{
+	LOG_DEBUG << "Validating Connection header...";
+
+	std::map<std::string, std::string>::const_iterator iter = request.headers.find("connection");
+	if (iter != request.headers.end()) {
+		if (iter->second.empty()) {
+			request.httpStatus = StatusBadRequest;
+			request.shallCloseConnection = true;
+			throw std::runtime_error(ERR_EMPTY_CONNECTION_VALUE);
+		}
+		if (iter->second.find(',') != std::string::npos) {
+			request.httpStatus = StatusBadRequest;
+			request.shallCloseConnection = true;
+			throw std::runtime_error(ERR_MULTIPLE_CONNECTION_VALUES);
+		}
+
+		if (iter->second == "close") {
+			request.shallCloseConnection = true;
+		} else if (iter->second == "keep-alive") {
+		} else {
+			request.httpStatus = StatusBadRequest;
+			request.shallCloseConnection = true;
+			throw std::runtime_error(ERR_INVALID_CONNECTION_VALUE);
+		}
+
+		LOG_DEBUG << "Valid Connection header: " << iter->second;
+	}
+
+	LOG_DEBUG << "No Connection header found.";
 }
 
 /* ====== HELPER FUNCTIONS ====== */

--- a/test/unit/test_parseHeader_Headers.cpp
+++ b/test/unit/test_parseHeader_Headers.cpp
@@ -150,7 +150,58 @@ TEST_F(ParseHeadersTest, ValidHostnameAsIPWithPort)
 	EXPECT_EQ(request.headers["host"], "177.3.1.1:65535");
 }
 
+TEST_F(ParseHeadersTest, CloseConnection)
+{
+	// Arrange
+
+	// Act
+	p.parseHeader(
+		"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+		request);
+
+	// Assert
+	EXPECT_EQ(request.headers["host"], "127.0.0.1");
+	EXPECT_EQ(request.shallCloseConnection, true);
+}
+
+TEST_F(ParseHeadersTest, KeepConnection)
+{
+	// Arrange
+
+	// Act
+	p.parseHeader(
+		"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n",
+		request);
+
+	// Assert
+	EXPECT_EQ(request.headers["host"], "127.0.0.1");
+	EXPECT_EQ(request.shallCloseConnection, false);
+}
+
 // NON-VALID HEADERS TEST SUITE
+
+TEST_F(ParseHeadersTest, InvalidConnectionHeader)
+{
+	// Arrange
+
+	// Act
+
+	// Assert
+	EXPECT_THROW(
+		{
+			try {
+				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: "
+							  "127.0.0.1\r\nConnection: doge\r\n\r\n",
+					request);
+
+			} catch (const std::runtime_error& e) {
+				EXPECT_STREQ(ERR_INVALID_CONNECTION_VALUE, e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
+				throw;
+			}
+		},
+		std::runtime_error);
+}
 
 TEST_F(ParseHeadersTest, WhitespaceBetweenHeaderFieldNameAndColon)
 {

--- a/test/unit/test_parseHeader_Headers.cpp
+++ b/test/unit/test_parseHeader_Headers.cpp
@@ -226,29 +226,6 @@ TEST_F(ParseHeadersTest, EmptyConnectionValue)
 		std::runtime_error);
 }
 
-TEST_F(ParseHeadersTest, MultipleConnectionValues)
-{
-	// Arrange
-
-	// Act
-
-	// Assert
-	EXPECT_THROW(
-		{
-			try {
-				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: "
-							  "127.0.0.1\r\nConnection: close, keep-alive, close\r\n\r\n",
-					request);
-
-			} catch (const std::runtime_error& e) {
-				EXPECT_STREQ(ERR_MULTIPLE_CONNECTION_VALUES, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
-				throw;
-			}
-		},
-		std::runtime_error);
-}
-
 TEST_F(ParseHeadersTest, WhitespaceBetweenHeaderFieldNameAndColon)
 {
 	// Arrange

--- a/test/unit/test_parseHeader_Headers.cpp
+++ b/test/unit/test_parseHeader_Headers.cpp
@@ -203,6 +203,52 @@ TEST_F(ParseHeadersTest, InvalidConnectionHeader)
 		std::runtime_error);
 }
 
+TEST_F(ParseHeadersTest, EmptyConnectionValue)
+{
+	// Arrange
+
+	// Act
+
+	// Assert
+	EXPECT_THROW(
+		{
+			try {
+				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: "
+							  "127.0.0.1\r\nConnection: \r\n\r\n",
+					request);
+
+			} catch (const std::runtime_error& e) {
+				EXPECT_STREQ(ERR_EMPTY_CONNECTION_VALUE, e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
+				throw;
+			}
+		},
+		std::runtime_error);
+}
+
+TEST_F(ParseHeadersTest, MultipleConnectionValues)
+{
+	// Arrange
+
+	// Act
+
+	// Assert
+	EXPECT_THROW(
+		{
+			try {
+				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: "
+							  "127.0.0.1\r\nConnection: close, keep-alive, close\r\n\r\n",
+					request);
+
+			} catch (const std::runtime_error& e) {
+				EXPECT_STREQ(ERR_MULTIPLE_CONNECTION_VALUES, e.what());
+				EXPECT_EQ(request.shallCloseConnection, true);
+				throw;
+			}
+		},
+		std::runtime_error);
+}
+
 TEST_F(ParseHeadersTest, WhitespaceBetweenHeaderFieldNameAndColon)
 {
 	// Arrange


### PR DESCRIPTION
Adds validateConnectionHeader():

- check against empty value
- check against multiple values
- check for correct value: close/keep-alive

Adds unit tests

closes #143 