### PR TITLE
167 adapt status code functions

### DIFF
--- a/inc/StatusCode.hpp
+++ b/inc/StatusCode.hpp
@@ -21,10 +21,11 @@ enum statusCode {
 	StatusNonSupportedVersion = 505
 };
 
-std::ostream& operator<<(std::ostream& ostream, statusCode statusCode);
-
+std::string statusCodeToString(statusCode status);
 std::string statusCodeToReasonPhrase(statusCode status);
 statusCode stringToStatusCode(std::string& str);
 statusCode extractStatusCode(const std::string& statusLine);
 bool isErrorStatus(statusCode statusCode);
 bool isRedirectionStatus(statusCode statusCode);
+
+std::ostream& operator<<(std::ostream& ostream, statusCode statusCode);

--- a/inc/StatusCode.hpp
+++ b/inc/StatusCode.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "constants.hpp"
+
+#include <cstdlib>
 #include <iostream>
 
 enum statusCode {
@@ -23,7 +26,7 @@ enum statusCode {
 
 std::string statusCodeToString(statusCode status);
 std::string statusCodeToReasonPhrase(statusCode status);
-statusCode stringToStatusCode(std::string& str);
+statusCode stringToStatusCode(const std::string& str);
 statusCode extractStatusCode(const std::string& statusLine);
 bool isErrorStatus(statusCode statusCode);
 bool isRedirectionStatus(statusCode statusCode);

--- a/src/LogOstreamInserters.cpp
+++ b/src/LogOstreamInserters.cpp
@@ -127,59 +127,7 @@ std::ostream& operator<<(std::ostream& ostream, Method method)
  */
 std::ostream& operator<<(std::ostream& ostream, statusCode statusCode)
 {
-	if (statusCode < NoStatus || statusCode > StatusNonSupportedVersion)
-		statusCode = StatusInternalServerError;
-
-	switch (statusCode) {
-	case NoStatus:
-		ostream << "0";
-		break;
-	case StatusOK:
-		ostream << "200";
-		break;
-	case StatusCreated:
-		ostream << "201";
-		break;
-	case StatusMovedPermanently:
-		ostream << "301";
-		break;
-	case StatusFound:
-		ostream << "302";
-		break;
-	case StatusPermanentRedirect:
-		ostream << "308";
-		break;
-	case StatusBadRequest:
-		ostream << "400";
-		break;
-	case StatusForbidden:
-		ostream << "403";
-		break;
-	case StatusNotFound:
-		ostream << "404";
-		break;
-	case StatusMethodNotAllowed:
-		ostream << "405";
-		break;
-	case StatusRequestTimeout:
-		ostream << "408";
-		break;
-	case StatusRequestEntityTooLarge:
-		ostream << "413";
-		break;
-	case StatusRequestHeaderFieldsTooLarge:
-		ostream << "431";
-		break;
-	case StatusInternalServerError:
-		ostream << "500";
-		break;
-	case StatusMethodNotImplemented:
-		ostream << "501";
-		break;
-	case StatusNonSupportedVersion:
-		ostream << "505";
-		break;
-	}
+	ostream << statusCodeToString(statusCode);
 	return ostream;
 }
 

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -1,5 +1,46 @@
 #include "StatusCode.hpp"
 
+std::string statusCodeToString(statusCode statusCode)
+{
+	if (statusCode < NoStatus || statusCode > StatusNonSupportedVersion)
+		return ("0");
+
+	switch (statusCode) {
+	case NoStatus:
+		return ("0");
+	case StatusOK:
+		return ("200");
+	case StatusCreated:
+		return ("201");
+	case StatusMovedPermanently:
+		return ("301");
+	case StatusFound:
+		return ("302");
+	case StatusPermanentRedirect:
+		return ("308");
+	case StatusBadRequest:
+		return ("400");
+	case StatusForbidden:
+		return ("403");
+	case StatusNotFound:
+		return ("404");
+	case StatusMethodNotAllowed:
+		return ("405");
+	case StatusRequestTimeout:
+		return ("408");
+	case StatusRequestEntityTooLarge:
+		return ("413");
+	case StatusRequestHeaderFieldsTooLarge:
+		return ("431");
+	case StatusInternalServerError:
+		return ("500");
+	case StatusMethodNotImplemented:
+		return ("501");
+	case StatusNonSupportedVersion:
+		return ("505");
+	}
+}
+
 /**
  * @brief Returns reason phrase for a given status code.
  *

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -122,42 +122,36 @@ bool isRedirectionStatus(statusCode statusCode)
  * @param str The string representation of the HTTP status code.
  * @return The corresponding statusCode enum value.
  */
-statusCode stringToStatusCode(std::string& str)
+statusCode stringToStatusCode(const std::string& str)
 {
-	if (str == "0")
-		return NoStatus;
-	if (str == "200")
-		return StatusOK;
-	if (str == "201")
-		return StatusCreated;
-	if (str == "301")
-		return StatusMovedPermanently;
-	if (str == "302")
-		return StatusFound;
-	if (str == "308")
-		return StatusPermanentRedirect;
-	if (str == "400")
-		return StatusBadRequest;
-	if (str == "403")
-		return StatusForbidden;
-	if (str == "404")
-		return StatusNotFound;
-	if (str == "405")
-		return StatusMethodNotAllowed;
-	if (str == "408")
-		return StatusRequestTimeout;
-	if (str == "413")
-		return StatusRequestEntityTooLarge;
-	if (str == "431")
-		return StatusRequestHeaderFieldsTooLarge;
-	if (str == "500")
-		return StatusInternalServerError;
-	if (str == "501")
-		return StatusMethodNotImplemented;
-	if (str == "505")
-		return StatusNonSupportedVersion;
+	if (str.size() != 3)
+		return (NoStatus);
 
-	return NoStatus;
+	char* endptr = NULL;
+	statusCode statusCode = static_cast<enum statusCode>(std::strtol(str.c_str(), &endptr, constants::g_decimalBase));
+	if (*endptr != '\0')
+		statusCode = NoStatus;
+
+	switch (statusCode) {
+	case NoStatus:
+	case StatusOK:
+	case StatusCreated:
+	case StatusMovedPermanently:
+	case StatusFound:
+	case StatusPermanentRedirect:
+	case StatusBadRequest:
+	case StatusForbidden:
+	case StatusNotFound:
+	case StatusRequestEntityTooLarge:
+	case StatusMethodNotAllowed:
+	case StatusRequestTimeout:
+	case StatusRequestHeaderFieldsTooLarge:
+	case StatusInternalServerError:
+	case StatusMethodNotImplemented:
+	case StatusNonSupportedVersion:
+		return (statusCode);
+	}
+	return (NoStatus);
 }
 
 statusCode extractStatusCode(const std::string& statusLine)

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -3,7 +3,7 @@
 std::string statusCodeToString(statusCode statusCode)
 {
 	if (statusCode < NoStatus || statusCode > StatusNonSupportedVersion)
-		return ("0");
+		statusCode = NoStatus;
 
 	switch (statusCode) {
 	case NoStatus:
@@ -51,7 +51,7 @@ std::string statusCodeToString(statusCode statusCode)
 std::string statusCodeToReasonPhrase(statusCode statusCode)
 {
 	if (statusCode < NoStatus || statusCode > StatusNonSupportedVersion)
-		statusCode = StatusInternalServerError;
+		statusCode = NoStatus;
 
 	switch (statusCode) {
 	case NoStatus:

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -1,5 +1,12 @@
 #include "StatusCode.hpp"
 
+/**
+ * @brief Converts a status code to a string.
+ *
+ * If the status code is not a known status code, it returns "0".
+ * @param statusCode Status code.
+ * @return std::string String representation of the status code.
+ */
 std::string statusCodeToString(statusCode statusCode)
 {
 	if (statusCode < NoStatus || statusCode > StatusNonSupportedVersion)
@@ -39,12 +46,13 @@ std::string statusCodeToString(statusCode statusCode)
 	case StatusNonSupportedVersion:
 		return ("505");
 	}
+	return ("0");
 }
 
 /**
  * @brief Returns reason phrase for a given status code.
  *
- * In case of NoStatus returns the string "NO STATUS CODE".
+ * If the status code is not known returns the string "NO STATUS CODE".
  * @param statusCode Status code.
  * @return std::string Reason phrase.
  */
@@ -87,38 +95,13 @@ std::string statusCodeToReasonPhrase(statusCode statusCode)
 	case StatusNonSupportedVersion:
 		return "HTTP Version Not Supported";
 	}
-}
-
-/**
- * @brief Check if a given status code is an error status code.
- *
- * An error status code is a 3xx, 4xx or 5xx status code.
- * @param statusCode Status code to check.
- * @return true If the status code is an error status code.
- * @return false If the status code is not an error status code.
- */
-bool isErrorStatus(statusCode statusCode) { return (statusCode >= StatusMovedPermanently); }
-
-/**
- * @brief Check if a given status code is a redirection.
- *
- * A redirection is a 3xx status code.
- * @param statusCode Status code to check.
- * @return true If the status code is a redirection.
- * @return false If the status code is not a redirection.
- */
-bool isRedirectionStatus(statusCode statusCode)
-{
-	return (statusCode >= StatusMovedPermanently && statusCode <= StatusPermanentRedirect);
+	return "NO STATUS CODE";
 }
 
 /**
  * @brief Converts a string to an HTTP status code.
  *
- * This function takes a string representation of an HTTP status code
- * and returns the corresponding statusCode enum value. If the string
- * does not match any known status code, it returns StatusBadRequest.
- *
+ * Expects the string to be exactly 3 numbers long. If the string is not a valid status code, it returns NoStatus.
  * @param str The string representation of the HTTP status code.
  * @return The corresponding statusCode enum value.
  */
@@ -154,6 +137,13 @@ statusCode stringToStatusCode(const std::string& str)
 	return (NoStatus);
 }
 
+/**
+ * @brief Extracts the status code from a status line.
+ *
+ * Extratcs from the first number found till the last number.
+ * @param statusLine The status line.
+ * @return The status code.
+ */
 statusCode extractStatusCode(const std::string& statusLine)
 {
 	size_t pos = statusLine.find_first_of("0123456789");
@@ -162,4 +152,27 @@ statusCode extractStatusCode(const std::string& statusLine)
 		return stringToStatusCode(statusCodeString);
 	}
 	return NoStatus;
+}
+
+/**
+ * @brief Check if a given status code is an error status code.
+ *
+ * An error status code is a 3xx, 4xx or 5xx status code.
+ * @param statusCode Status code to check.
+ * @return true If the status code is an error status code.
+ * @return false If the status code is not an error status code.
+ */
+bool isErrorStatus(statusCode statusCode) { return (statusCode >= StatusMovedPermanently); }
+
+/**
+ * @brief Check if a given status code is a redirection.
+ *
+ * A redirection is a 3xx status code.
+ * @param statusCode Status code to check.
+ * @return true If the status code is a redirection.
+ * @return false If the status code is not a redirection.
+ */
+bool isRedirectionStatus(statusCode statusCode)
+{
+	return (statusCode >= StatusMovedPermanently && statusCode <= StatusPermanentRedirect);
 }


### PR DESCRIPTION
- extract conversion logic out of ostream inserter into own function statusCodeToString. Use this function in ostream inserter
- added return for both statusCodeToString and statusCodeToReasonPhrase in case of no switch case matches
- refactor stringToStatusCode to convert the string and the check with switch case
   - with str.size() != 3 we can make fast check if it can be valid status code, as every status code is 3 numbers long
   - with switch case we get compiler warning if we add a new status code --> we can't forget 
- update Doxgen 