### PR TITLE
166 set shallcloseconnection in responsebuilder

### DIFF
--- a/inc/StatusCode.hpp
+++ b/inc/StatusCode.hpp
@@ -28,3 +28,4 @@ statusCode stringToStatusCode(std::string& str);
 statusCode extractStatusCode(const std::string& statusLine);
 bool isErrorStatus(statusCode statusCode);
 bool isRedirectionStatus(statusCode statusCode);
+bool isCloseConnectionStatus(statusCode statusCode);

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -44,6 +44,9 @@ void ResponseBuilder::buildResponse(Connection& connection)
 
 	LOG_DEBUG << "Building response for request: " << request.method << " " << request.uri.path;
 
+	if (isCloseConnectionStatus(request.httpStatus))
+		request.shallCloseConnection = true;
+
 	ResponseBodyHandler responseBodyHandler(connection, m_responseBody, m_responseHeaders, m_fileSystemOps);
 	responseBodyHandler.execute();
 

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -72,6 +72,29 @@ bool isRedirectionStatus(statusCode statusCode)
 }
 
 /**
+ * @brief Check if a given status code closes connection
+ *
+ * Connection: close is sent with status:
+ * - 400 Bad Request
+ * - 413 Request Entity Too Large
+ * - 431 Request Header Fields Too Large
+ * @param statusCode Status code to check.
+ * @return true If status code closes connection
+ * @return false If status code doesn't close connection
+ */
+bool isCloseConnectionStatus(statusCode statusCode)
+{
+	switch (statusCode) {
+	case StatusBadRequest:
+	case StatusRequestEntityTooLarge:
+	case StatusRequestHeaderFieldsTooLarge:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/**
  * @brief Converts a string to an HTTP status code.
  *
  * This function takes a string representation of an HTTP status code

--- a/src/StatusCode.cpp
+++ b/src/StatusCode.cpp
@@ -76,6 +76,8 @@ bool isRedirectionStatus(statusCode statusCode)
  *
  * Connection: close is sent with status:
  * - 400 Bad Request
+ * - 405 Method Not Allowed
+ * - 408 Request Timeout
  * - 413 Request Entity Too Large
  * - 431 Request Header Fields Too Large
  * @param statusCode Status code to check.
@@ -86,6 +88,8 @@ bool isCloseConnectionStatus(statusCode statusCode)
 {
 	switch (statusCode) {
 	case StatusBadRequest:
+	case StatusMethodNotAllowed:
+	case StatusRequestTimeout:
 	case StatusRequestEntityTooLarge:
 	case StatusRequestHeaderFieldsTooLarge:
 		return true;

--- a/test/integration/server_response/test_GET.py
+++ b/test/integration/server_response/test_GET.py
@@ -15,7 +15,10 @@ def test_GET_simple():
     response = make_request(url)
     file_path = "/workspaces/webserv/html/index.html"
     file_size = os.path.getsize(file_path)
+    assert response.headers["content-type"] == "text/html"
     assert int(response.headers["content-length"]) == file_size
+    assert response.headers["Server"] == "TriHard"
+    assert response.headers["connection"] == "keep-alive"
     assert response.status_code == 200
 
 def test_GET_index_file():

--- a/test/integration/server_response/test_error4xx.py
+++ b/test/integration/server_response/test_error4xx.py
@@ -270,3 +270,4 @@ def test_method_not_allowed():
 
     assert response.status_code == 405
     assert response.headers["allow"] == "GET"
+    assert response.headers["connection"] == "close"

--- a/test/integration/server_response/test_error4xx.py
+++ b/test/integration/server_response/test_error4xx.py
@@ -73,6 +73,7 @@ def test_4xx_missing_host_header():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_percent_encoding_invalid_char():
     with socket.create_connection((host, port)) as sock:
@@ -81,6 +82,7 @@ def test_4xx_percent_encoding_invalid_char():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_percent_encoding_incomplete():
     with socket.create_connection((host, port)) as sock:
@@ -89,6 +91,7 @@ def test_4xx_percent_encoding_incomplete():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_percent_encoding_non_hex():
     with socket.create_connection((host, port)) as sock:
@@ -97,6 +100,7 @@ def test_4xx_percent_encoding_non_hex():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_directory_traversal():
     with socket.create_connection((host, port)) as sock:
@@ -105,6 +109,7 @@ def test_4xx_directory_traversal():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 # Does not work, gets misinterpreted as method not implemented > a empty line can't enter RequestParser
 # def test_4xx_no_request_line():
@@ -122,6 +127,7 @@ def test_4xx_request_line_does_not_start_with_slash():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_not_allowed_char():
     with socket.create_connection((host, port)) as sock:
@@ -130,6 +136,7 @@ def test_4xx_not_allowed_char():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_not_allowed_char():
     with socket.create_connection((host, port)) as sock:
@@ -138,6 +145,7 @@ def test_4xx_not_allowed_char():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_header_name_ends_in_space():
     with socket.create_connection((host, port)) as sock:
@@ -146,6 +154,7 @@ def test_4xx_header_name_ends_in_space():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_char_in_header_name():
     with socket.create_connection((host, port)) as sock:
@@ -154,6 +163,7 @@ def test_4xx_char_in_header_name():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 400
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_request_too_long():
     with socket.create_connection((host, port)) as sock:
@@ -162,6 +172,7 @@ def test_4xx_request_too_long():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 431
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_chunk_size_too_big():
     with socket.create_connection((host, port)) as sock:
@@ -170,6 +181,7 @@ def test_4xx_chunk_size_too_big():
 
         response = parse_http_response(sock)
         assert response["status_code"] == 413
+        assert response["headers"].get("connection") == "close"
 
 def test_4xx_epoll_partial_and_complete_requests():
     # Create two sockets
@@ -195,7 +207,9 @@ def test_4xx_epoll_partial_and_complete_requests():
     response2 = parse_http_response(client2)
 
     assert response1["status_code"] == 400
+    assert response1["headers"].get("connection") == "close"
     assert response2["status_code"] == 200
+    assert response2["headers"].get("connection") == "keep-alive"
 
     client1.close()
     client2.close()
@@ -243,6 +257,7 @@ def test_4xx_file_too_big():
     response = make_request(url, method="POST", data=binary_data)
 
     assert response.status_code == 413
+    assert response.headers["connection"] == "close"
     # Check that file does not exist
     assert os.path.isfile(dst_file_path) == False
 

--- a/test/integration/utils/utils.py
+++ b/test/integration/utils/utils.py
@@ -3,7 +3,7 @@ import os
 import time
 import requests
 import pytest
-from typing import Optional, Dict
+from typing import Optional, Dict, Union
 import socket
 
 def start_server(
@@ -133,7 +133,7 @@ def make_request(
     except requests.exceptions.RequestException as e:
         pytest.fail(f"Failed to make request to {url} with method {method}: {e}", pytrace=False)
 
-def parse_http_response(sock: socket.socket) -> Dict[str, str]:
+def parse_http_response(sock: socket.socket) -> Dict[str, Union[int, Dict[str, str], str]]:
     """
     Parse the HTTP response from a socket object and return the status code, headers, and body.
 
@@ -165,7 +165,7 @@ def parse_http_response(sock: socket.socket) -> Dict[str, str]:
         if line.strip() == "":  # An empty line indicates the end of headers
             break
         key, value = line.split(":", 1)  # Split header line into key and value
-        headers[key.strip()] = value.strip()  # Store header in dictionary, stripping whitespace
+        headers[key.strip().lower()] = value.strip()  # Store header in dictionary, stripping whitespace
 
     # Extract the body, which comes after a double CRLF sequence (\r\n\r\n)
     body = response_str.split('\r\n\r\n', 1)[1] if '\r\n\r\n' in response_str else ""

--- a/test/unit/test_MultipartFormdata.cpp
+++ b/test/unit/test_MultipartFormdata.cpp
@@ -45,7 +45,6 @@ TEST_F(MultipartFormdataTest, ParseHeaderNoBoundary)
 				p.parseHeader(headerString, request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_BAD_MULTIPART_FORMDATA, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},

--- a/test/unit/test_handleBody.cpp
+++ b/test/unit/test_handleBody.cpp
@@ -25,7 +25,6 @@ TEST_F(HandleBodyTest, ParseBodyFailed)
 	handleBody(m_server, m_dummyFd, m_connection);
 
 	EXPECT_EQ(m_connection.m_request.httpStatus, StatusBadRequest);
-	EXPECT_TRUE(m_connection.m_request.shallCloseConnection);
 	EXPECT_EQ(m_connection.m_status, Connection::BuildResponse);
 }
 

--- a/test/unit/test_parseHeader_Headers.cpp
+++ b/test/unit/test_parseHeader_Headers.cpp
@@ -210,7 +210,6 @@ TEST_F(ParseHeadersTest, InvalidConnectionHeader)
 
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_CONNECTION_VALUE, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -233,7 +232,6 @@ TEST_F(ParseHeadersTest, EmptyConnectionValue)
 
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_EMPTY_CONNECTION_VALUE, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -253,7 +251,6 @@ TEST_F(ParseHeadersTest, WhitespaceBetweenHeaderFieldNameAndColon)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_HEADER_COLON_WHITESPACE, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -273,7 +270,6 @@ TEST_F(ParseHeadersTest, ObsoleteLineFolding)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_OBSOLETE_LINE_FOLDING, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -293,7 +289,6 @@ TEST_F(ParseHeadersTest, InvalidFieldName)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_HEADER_NAME_INVALID_CHAR, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -313,7 +308,6 @@ TEST_F(ParseHeadersTest, EmptyContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_CONTENT_LENGTH, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -333,7 +327,6 @@ TEST_F(ParseHeadersTest, InvalidContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_CONTENT_LENGTH, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -353,7 +346,6 @@ TEST_F(ParseHeadersTest, RepeatedNonEqualContentLengths)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_MULTIPLE_CONTENT_LENGTH_VALUES, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -373,7 +365,6 @@ TEST_F(ParseHeadersTest, InvalidInFirstRepeatedContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_CONTENT_LENGTH, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -393,7 +384,6 @@ TEST_F(ParseHeadersTest, InvalidInLastRepeatedContentLength)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_CONTENT_LENGTH, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -413,7 +403,6 @@ TEST_F(ParseHeadersTest, RepeatedContentLengthHeaders)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_MULTIPLE_CONTENT_LENGTH_VALUES, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -433,7 +422,6 @@ TEST_F(ParseHeadersTest, EmptyTransferEncoding)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_NON_EXISTENT_TRANSFER_ENCODING, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -453,7 +441,6 @@ TEST_F(ParseHeadersTest, InvalidChunkedTransferEncodingPositioning)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_NON_FINAL_CHUNKED_ENCODING, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -490,7 +477,6 @@ TEST_F(ParseHeadersTest, MissingHostHeader)
 				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_MISSING_HOST_HEADER, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -508,7 +494,6 @@ TEST_F(ParseHeadersTest, EmptyHostValue)
 				p.parseHeader("GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost:\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_EMPTY_HOST_VALUE, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -528,7 +513,6 @@ TEST_F(ParseHeadersTest, MultipleHostHeaders)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_MULTIPLE_HOST_HEADERS, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -548,7 +532,6 @@ TEST_F(ParseHeadersTest, HostnameInvalidChar)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -568,7 +551,6 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtStart)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -588,7 +570,6 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtStartOfLabel)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -608,7 +589,6 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtEndOfLabel)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -628,7 +608,6 @@ TEST_F(ParseHeadersTest, HostnameInvalidHyphenAtEnd)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -649,7 +628,6 @@ TEST_F(ParseHeadersTest, HostnameLabelTooLong)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -671,7 +649,6 @@ TEST_F(ParseHeadersTest, HostnameTooLong)
 					request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOSTNAME, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -690,7 +667,6 @@ TEST_F(ParseHeadersTest, HostnameAsIPInvalid)
 					"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 377.3.1.999\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOST_IP, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -710,7 +686,6 @@ TEST_F(ParseHeadersTest, InvalidHostnameLikeIP)
 					"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 377.3.1.9999\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOST_IP, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -730,7 +705,6 @@ TEST_F(ParseHeadersTest, InvalidHostnameLikeIP2)
 					"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 127.3.43.1.1\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOST_IP, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},
@@ -749,7 +723,6 @@ TEST_F(ParseHeadersTest, HostnameAsIPWithInvalidPort)
 					"GET /search?query=openai&year=2024#conclusion HTTP/1.1\r\nHost: 177.3.1.1:65536\r\n\r\n", request);
 			} catch (const std::runtime_error& e) {
 				EXPECT_STREQ(ERR_INVALID_HOST_IP_WITH_PORT, e.what());
-				EXPECT_EQ(request.shallCloseConnection, true);
 				throw;
 			}
 		},


### PR DESCRIPTION
- new function isCloseConnectionStatus() which checks if request has closing status and sets bool
- implemented in ResponseBuilder as first check
- removed `request.shallCloseConnection = true` lines in RequestParser and Server 
- adapted integration tests to check for header connection