### PR TITLE
172 implement static values for epoll

### DIFF
--- a/cgi-bin/infinite.sh
+++ b/cgi-bin/infinite.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while true; do
+    sleep 1
+done

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -50,6 +50,8 @@
  */
 class Server {
 public:
+	static const int s_maxEvents = 10; /**< Maximum number of events to process via epoll */
+	static const int s_epollTimeout = 1000; /**< Timeout for epoll_wait in milliseconds */
 	static const int s_backlog = 10; /**< Default backlog for listening sockets */
 	static const time_t s_clientTimeout = 60; /**< Default timeout for a Connection in seconds */
 	static const std::size_t s_bufferSize = 1024; /**< Default buffer size for reading from sockets in Bytes */

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1515,7 +1515,7 @@ void checkForTimeout(Server& server)
 		LOG_DEBUG << iter->second.m_clientSocket << ": Time since last event: " << timeSinceLastEvent;
 		if (timeSinceLastEvent > server.getClientTimeout()) {
 			LOG_INFO << "Connection timeout: " << iter->second.m_clientSocket;
-			iter->second.m_status = Connection::Timeout;
+			LOG_DEBUG << "Timed out with status " << iter->second.m_status;
 			if (iter->second.m_status == Connection::ReceiveFromCGI || iter->second.m_status == Connection::SendToCGI) {
 				server.addEvent(iter->first, EPOLLOUT);
 				if (iter->second.m_pipeToCGIWriteEnd != -1)
@@ -1524,6 +1524,7 @@ void checkForTimeout(Server& server)
 					webutils::closeFd(iter->second.m_pipeFromCGIReadEnd);
 			} else
 				server.modifyEvent(iter->first, EPOLLOUT);
+			iter->second.m_status = Connection::Timeout;
 		}
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,18 +37,17 @@ int main(const int argc, const char* argv[])
 		return 1;
 	}
 
-	// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-	const std::string configFilePath = (argc == 1) ? XSTRINGIZE(DEFAULT_CONFIG_PATH) : argv[1];
-	std::cout << "Config file path: " << configFilePath << '\n';
-
 	weblog::initConsole(weblog::LevelDebug);
 
-	if (!registerSignals()) {
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+	const std::string configFilePath = (argc == 1) ? XSTRINGIZE(DEFAULT_CONFIG_PATH) : argv[1];
+	LOG_INFO << "Config file path: " << configFilePath << '\n';
+
+	if (!registerSignals())
 		return 1;
-	}
 
 	try {
-		EpollWrapper epollWrapper(10, -1);
+		EpollWrapper epollWrapper(Server::s_maxEvents, Server::s_maxEvents);
 		FileSystemOps fileSystemOps;
 		SocketOps socketOps;
 		ProcessOps processOps;
@@ -57,7 +56,7 @@ int main(const int argc, const char* argv[])
 		ConfigFile configFile = parser.parseConfigFile(configFilePath);
 
 		Server server(configFile, epollWrapper, fileSystemOps, socketOps, processOps);
-		initVirtualServers(server, 10, server.getServerConfigs());
+		initVirtualServers(server, Server::s_backlog, server.getServerConfigs());
 		runServer(server);
 	} catch (std::exception& e) {
 		LOG_ERROR << e.what();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(const int argc, const char* argv[])
 		return 1;
 
 	try {
-		EpollWrapper epollWrapper(Server::s_maxEvents, Server::s_maxEvents);
+		EpollWrapper epollWrapper(Server::s_maxEvents, Server::s_epollTimeout);
 		FileSystemOps fileSystemOps;
 		SocketOps socketOps;
 		ProcessOps processOps;

--- a/test/integration/pytest.ini
+++ b/test/integration/pytest.ini
@@ -6,4 +6,6 @@
 # -s : no capture. Pytest automatically captures stdout/stderr. With -s this output is printed
 
 [pytest]
-addopts = -v
+addopts = -v -m "not timeout"
+markers =
+    timeout: Tests related to request timeouts

--- a/test/integration/server_response/test_timeout.py
+++ b/test/integration/server_response/test_timeout.py
@@ -1,0 +1,53 @@
+# This module is for requests which time out.
+
+from utils.utils import parse_http_response
+from utils.utils import make_request
+import socket
+import time
+import pytest
+
+host = "localhost"
+port = 8080
+wait_for_timeout = 61
+
+@pytest.mark.timeout
+def test_timeout_partial_request_sent():
+    with socket.create_connection((host, port)) as sock:
+        request = b"GET / HTTP/1.1\r\n"
+        sock.sendall(request)
+        time.sleep(wait_for_timeout)
+
+        response = parse_http_response(sock)
+        assert response["status_code"] == 408
+        assert response["headers"].get("connection") == "close"
+
+@pytest.mark.timeout
+def test_timeout_full_request_partial_body():
+    with socket.create_connection((host, port)) as sock:
+        request = b"POST /uploads/tooslow.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 300\r\n\r\nI am too slow"
+        sock.sendall(request)
+        time.sleep(wait_for_timeout)
+
+        response = parse_http_response(sock)
+        assert response["status_code"] == 408
+        assert response["headers"].get("connection") == "close"
+
+@pytest.mark.timeout
+def test_timeout_full_request_then_nothing():
+    with socket.create_connection((host, port)) as sock:
+        request = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        sock.sendall(request)
+        response = parse_http_response(sock)
+        assert response["status_code"] == 200
+        time.sleep(wait_for_timeout)
+
+        response = parse_http_response(sock)
+        assert response["status_code"] == 408
+        assert response["headers"].get("connection") == "close"
+
+@pytest.mark.timeout
+def test_timeout_infinite_CGI():
+    url = "http://localhost:8080/cgi-bin/infinite.sh"
+    response = make_request(url, timeout=wait_for_timeout)
+    assert response.status_code == 408
+    assert response.headers["connection"] == "close"


### PR DESCRIPTION
- Implemented s_maxEvents and s_epollTimeout and use them in main
- Also moved init of logger up to be able to log configfile path.
- Little bugfix: while checking for error in checkForTimeout (missing brackets) I moved setting of status Timeout too high. We never entered the CGI cases --> fixed
- add new integration test_timeout.py. Tries to simulate timeout. Since we don't have way to dynamically change timeout value these take very long (60 sec a pop). Added marker and deactivated timeout tests for "normal"  test run --> -m "not timeout" in pytest.ini. If removed will also run timeout tests
- added script infinite.sh, which just has infinite loop --> used for testing