### PR TITLE
165 trimtrailingwhitespace should return string

### DIFF
--- a/inc/utilities.hpp
+++ b/inc/utilities.hpp
@@ -17,10 +17,9 @@
 
 namespace webutils {
 
-const int timeStringBuffer = 80;
-
 std::string trimLeadingWhitespaces(const std::string& str);
-void trimTrailingWhiteSpaces(std::string& str);
+std::string trimTrailingWhiteSpaces(const std::string& str);
+std::string trimWhiteSpaces(const std::string& str);
 std::vector<std::string> split(const std::string& str, const std::string& delimiter);
 
 std::string getFileExtension(const std::string& path);

--- a/src/ConfigFileParser.cpp
+++ b/src/ConfigFileParser.cpp
@@ -379,8 +379,7 @@ bool ConfigFileParser::readAndTrimLine(const std::string& content, char delimite
 
 		m_currentLine = content.substr(startIndex, m_contentIndex - startIndex);
 
-		m_currentLine = webutils::trimLeadingWhitespaces(m_currentLine);
-		webutils::trimTrailingWhiteSpaces(m_currentLine);
+		m_currentLine = webutils::trimWhiteSpaces(m_currentLine);
 
 		return false;
 	}
@@ -388,8 +387,7 @@ bool ConfigFileParser::readAndTrimLine(const std::string& content, char delimite
 	m_contentIndex++;
 	m_currentLine = content.substr(startIndex, m_contentIndex - startIndex);
 
-	m_currentLine = webutils::trimLeadingWhitespaces(m_currentLine);
-	webutils::trimTrailingWhiteSpaces(m_currentLine);
+	m_currentLine = webutils::trimWhiteSpaces(m_currentLine);
 	return true;
 }
 
@@ -1008,8 +1006,7 @@ std::string ConfigFileParser::getDirective() const
 	else
 		directive = m_currentLine.substr(0, firstWhiteSpaceIndex);
 
-	directive = webutils::trimLeadingWhitespaces(directive);
-	webutils::trimTrailingWhiteSpaces(directive);
+	directive = webutils::trimWhiteSpaces(directive);
 
 	return directive;
 }
@@ -1030,8 +1027,7 @@ std::string ConfigFileParser::getValue(void) const
 	else
 		value = m_currentLine.substr(firstWhiteSpaceIndex, semicolonIndex - firstWhiteSpaceIndex);
 
-	value = webutils::trimLeadingWhitespaces(value);
-	webutils::trimTrailingWhiteSpaces(value);
+	value = webutils::trimWhiteSpaces(value);
 
 	return value;
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -359,8 +359,7 @@ void RequestParser::parseHeaders(HTTPRequest& request)
 			std::string headerValue = headerLine.substr(delimiterPos + 1);
 			if (headerValue[headerValue.size() - 1] == '\r')
 				headerValue.erase(headerValue.size() - 1);
-			headerValue = webutils::trimLeadingWhitespaces(headerValue);
-			webutils::trimTrailingWhiteSpaces(headerValue);
+			headerValue = webutils::trimWhiteSpaces(headerValue);
 			validateContentLength(headerName, headerValue, request);
 			validateNoMultipleHostHeaders(headerName, request);
 			request.headers[headerName] = headerValue;

--- a/src/ResponseBodyHandler.cpp
+++ b/src/ResponseBodyHandler.cpp
@@ -210,8 +210,7 @@ void ResponseBodyHandler::parseCGIResponseHeaders()
 		if (delimiterPos != std::string::npos) {
 			const std::string headerName = webutils::lowercase(header.substr(0, delimiterPos));
 			std::string headerValue = header.substr(delimiterPos + 1);
-			headerValue = webutils::trimLeadingWhitespaces(headerValue);
-			webutils::trimTrailingWhiteSpaces(headerValue);
+			headerValue = webutils::trimWhiteSpaces(headerValue);
 			m_responseHeaders[headerName] = headerValue;
 			LOG_DEBUG << "Parsed response header: " << headerName << " -> " << headerValue;
 		}

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -29,17 +29,30 @@ std::string trimLeadingWhitespaces(const std::string& str)
  *
  * This function removes all trailing white spaces (spaces, tabs, newlines, etc.)
  * from the input string.
- *
- * @param str The string to be trimmed. The string is modified in place.
- *
+ * @param str The string to be trimmed.
+ * @return std::string The trimmed string.
  */
-void trimTrailingWhiteSpaces(std::string& str)
+std::string trimTrailingWhiteSpaces(const std::string& str)
 {
 	std::string::size_type end = str.size();
 
 	while (end > 0 && (std::isspace(str.at(end - 1)) != 0))
 		--end;
-	str.erase(end);
+	return str.substr(0, end);
+}
+
+/**
+ * @brief Trims leading and trailing white spaces from a string.
+ *
+ * This function removes all leading and trailing white spaces (spaces, tabs, newlines, etc.)
+ * from the input string.
+ *
+ * @param str The string to be trimmed.
+ * @return std::string The trimmed string.
+ */
+std::string trimWhiteSpaces(const std::string& str)
+{
+	return trimLeadingWhitespaces(trimTrailingWhiteSpaces(str));
 }
 
 /**

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -103,7 +103,8 @@ std::string getFileExtension(const std::string& path)
  */
 std::string getGMTString(const time_t now, const std::string& format)
 {
-	char string[webutils::timeStringBuffer];
+	const int timeStringBuffer = 80;
+	char string[timeStringBuffer];
 
 	static_cast<void>(strftime(string, sizeof(string), format.c_str(), gmtime(&now)));
 	return string;
@@ -119,7 +120,8 @@ std::string getGMTString(const time_t now, const std::string& format)
  */
 std::string getLocaltimeString(const time_t now, const std::string& format)
 {
-	char string[webutils::timeStringBuffer];
+	const int timeStringBuffer = 80;
+	char string[timeStringBuffer];
 
 	static_cast<void>(strftime(string, sizeof(string), format.c_str(), localtime(&now)));
 	return string;


### PR DESCRIPTION
- trimtrailingwhitespace now returns std::string. It can be chained.
- added convenience function trimWhiteSpaces which trims leading and trailing
- implemented trimWhiteSpaces
- removed timeStringBuffer - was a global :o Made own value in respective functions