### PR TITLE
179 fix directive inheritance

### DIFF
--- a/inc/ConfigFileParser.hpp
+++ b/inc/ConfigFileParser.hpp
@@ -46,6 +46,7 @@ private:
 	size_t m_locationIndex;
 	bool m_hasServerRoot;
 	bool m_hasLocationRoot;
+	bool m_hasLocationMaxBodySize;
 	std::vector<std::string> m_validLocationDirectives;
 	bool m_isDefaultLocationDefined;
 	static const char* const s_whitespace;

--- a/src/ConfigFileParser.cpp
+++ b/src/ConfigFileParser.cpp
@@ -347,7 +347,7 @@ void ConfigFileParser::processLocationContent(const std::string& locationBlockCo
 	ConfigServer& server = m_configFile.servers[m_serverIndex];
 	Location& location = server.locations[m_locationIndex];
 
-	if (location.root != "html" && !location.alias.empty())
+	if (m_hasLocationRoot && !location.alias.empty())
 		throw std::runtime_error(ERR_ROOT_AND_ALIAS_DEFINED);
 	if (!m_hasLocationRoot)
 		location.root = server.root;

--- a/test/config_files/directive_inheritance.conf
+++ b/test/config_files/directive_inheritance.conf
@@ -3,9 +3,17 @@ http {
         listen 127.0.0.1:80;
         server_name example.com;
         root /var/www/html;
+		client_max_body_size 2m;
+		error_page 403 /403.html 404 /404.html;
 
-        location / {
+        location /upload_video {
             autoindex on;
+			allow_methods GET POST;
+        }
+		location /upload_images {
+            autoindex on;
+			client_max_body_size 1m;
+			allow_methods GET POST;
         }
     }
 }

--- a/test/unit/src/test_ConfigFileParser.cpp
+++ b/test/unit/src/test_ConfigFileParser.cpp
@@ -1582,5 +1582,16 @@ TEST_F(ValidConfigFileTests, DirectiveInheritance)
 {
 	ConfigFile configFile;
 	EXPECT_NO_THROW(configFile = m_configFileParser.parseConfigFile("test/config_files/directive_inheritance.conf"));
-	EXPECT_EQ("/var/www/html", configFile.servers[0].locations[0].root);
+
+	// location '/upload_videos'
+	EXPECT_EQ("/var/www/html", configFile.servers[0].locations[1].root);
+	EXPECT_EQ(constants::g_oneMegabyte * 2, configFile.servers[0].locations[1].maxBodySize);
+	EXPECT_EQ("/403.html", configFile.servers[0].locations[1].errorPage[StatusForbidden]);
+	EXPECT_EQ("/404.html", configFile.servers[0].locations[1].errorPage[StatusNotFound]);
+
+	// location '/upload_images'
+	EXPECT_EQ("/var/www/html", configFile.servers[0].locations[2].root);
+	EXPECT_EQ(constants::g_oneMegabyte, configFile.servers[0].locations[2].maxBodySize);
+	EXPECT_EQ("/403.html", configFile.servers[0].locations[2].errorPage[StatusForbidden]);
+	EXPECT_EQ("/404.html", configFile.servers[0].locations[2].errorPage[StatusNotFound]);
 }


### PR DESCRIPTION
 Refer to issue #179 for more information.

# Additional var

I added the var ``m_hasLocationMaxBodySize`` to indicate if a value for the directive client_max_body_size was specified within the config file.

# Refactor

When now a value is succesfully read for the directives:

- root
- client_max_body_size

within a location, the vars ``m_hasLocationRoot`` and ``m_hasLocationMaxBodySize`` are set to true. 

Therefore the checks, if those directives should inherit the values from the server block, were adapted:

```cpp
if (!m_hasLocationRoot)
	location.root = server.root;
if (!m_hasLocationMaxBodySize)
	location.maxBodySize = server.maxBodySize;
if (location.errorPage.empty())
	location.errorPage = server.errorPage;
```

# Test

The test for the directive inheritance was updated by including another location. 
This additional location specifies the value ``1m`` for the directive client_max_body_size. 
The expected behaviour is that this directive keeps the value ``1m`` and does not inherit the value from the server.

Closes #179